### PR TITLE
Remove `--production` flag from Docker build postinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /public
 COPY package.json /app/package.json
 RUN npm --loglevel warn install --production --no-optional
 COPY . /app
-RUN npm --loglevel warn run postinstall --production
+RUN npm --loglevel warn run postinstall
 RUN chown -R nodejs:nodejs /public
 
 USER nodejs


### PR DESCRIPTION
The production flag prevents the postinstall script from being run, and so means assets are not compiled in production deployments.