### PR TITLE
update jquery & remove package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ reports
 public/js/bundle.js
 .yardoc
 doc
-Gemfile.lock
 apps/**/translations/en
 dump.rdb
 coverage
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "hof-theme-govuk": "^2.0.4",
     "hogan.js": "^3.0.2",
     "i18n-future": "^1.1.0",
-    "jquery": "^1.9.3",
+    "jquery": "^3.3.1",
     "moment": "^2.10.3",
     "moment-business": "^2.0.0",
     "nodemailer": "^2.7.0",


### PR DESCRIPTION
update jquery for security vulnerability

remove package-lock as we don't use them

I attempted to remove gemfile.lock but this version proved useful for installing and running the cucumber tests.

If gemfile.lock is to be removed it would require more investigation and a separate PR.  