### PR TITLE
Ignore documentation from docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 node_modules
-kube
+documentation
 public
 apps/**/translations/**/default.json
 LICENSE.md


### PR DESCRIPTION
This is to trigger a new build, because the last is failing when trying to clone