### PR TITLE
SD 110: 'Start Again' button after session timeout fails

### DIFF
--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -14,7 +14,7 @@
 
 {{$content}}
     <p>{{{content.message}}}</p>
-    <a href="/{{startLink}}" class="button" role="button">Start again</a>
+    <a href="{{startLink}}" class="button" role="button">Start again</a>
     {{#showStack}}
       <pre>
         {{error.stack}}

--- a/errors/index.js
+++ b/errors/index.js
@@ -31,7 +31,6 @@ module.exports = function errorHandler(err, req, res, next) {
   res.statusCode = err.status || 500;
 
   logger.error(err.message || err.error, err);
-
   res.render(err.template, {
     error: err,
     content: content,

--- a/errors/index.js
+++ b/errors/index.js
@@ -31,6 +31,7 @@ module.exports = function errorHandler(err, req, res, next) {
   res.statusCode = err.status || 500;
 
   logger.error(err.message || err.error, err);
+
   res.render(err.template, {
     error: err,
     content: content,


### PR DESCRIPTION
[https://collaboration.homeoffice.gov.uk/jira/browse/SD-110]

What: The href on the start again button was adding an extra '/' which was causing an error instead of redirecting to a known page when the session had expired and had to be restarted.

Why: After a session timeout the attached screen is shown.  But clicking the start again button fails.