### PR TITLE
SD-480: remove GA Tracking script from custom layout

### DIFF
--- a/apps/common/views/layout.html
+++ b/apps/common/views/layout.html
@@ -20,25 +20,6 @@
       {{> partials-maincontent-left}}
     </div>
 
-    {{#gaTagId}}
-      <script{{#nonce}} nonce="{{nonce}}"{{/nonce}}>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', '{{gaTagId}}', 'auto');
-        ga('send', 'pageview');
-
-        ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
-        ga('govuk_shared.require', 'linker');
-        ga('govuk_shared.linker.set', 'anonymizeIp', true);
-        ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
-
-        ga('govuk_shared.send', 'pageview');
-
-      </script>
-    {{/gaTagId}}
     <script type="text/javascript" src="/public/js/bundle.js"></script>
   </main>
 {{/main}}


### PR DESCRIPTION
### What
Ticket: https://collaboration.homeoffice.gov.uk/jira/browse/SD-480
Removes script which initiates GA tag tracking from layout file used across all routes
### Why
At request of the Cabinet Office to become GDPR compliant