### PR TITLE
SD-798 Add nationalities to drop down list

### DIFF
--- a/apps/common/fields/personal-details.js
+++ b/apps/common/fields/personal-details.js
@@ -14,7 +14,7 @@ module.exports = {
   nationality: {
     validate: ['required'],
     className: ['typeahead', 'js-hidden'],
-    options: [''].concat(require('../../../assets/countries').nonEuCountries),
+    options: [''].concat(require('../../../assets/countries').allCountries),
     hint: 'fields.nationality.hint'
   },
   passport: {


### PR DESCRIPTION
# What
- make sure all EEA countries appear when selecting nationality in personal details

# Why 
the fact that EEA Nationals are not available on the BRP reporting forms is starting to become an issue and we are aware of an increasing need for us to provide the facility

# How
modified personal-details.js to accept all countries so that it includes ER countries

# Testing
Tested locally through all app routes