### PR TITLE
Upgraded hof-middlware to v2.2.4 to fix redirection to malicious site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7626,11 +7626,12 @@
       }
     },
     "hof-middleware": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/hof-middleware/-/hof-middleware-2.1.1.tgz",
-      "integrity": "sha512-ub8J5zrg/Qz5M/elUHFKJcGbwIXHXTzwR8+QZd3uZXfLa+9+egd+oHwQx4i+2e6m2FmylqCkrKrocBpmZqGuxw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/hof-middleware/-/hof-middleware-2.2.4.tgz",
+      "integrity": "sha512-XtuxxVyeJGkdtoh+dz0NfiBlDx9tgTvfAub2flO/U984LPgr0lLOGFhIzxFA0uChNup9tMv0ehsWV9qDzCLBRA==",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.13.1",
+        "urijs": "^1.19.2"
       }
     },
     "hof-middleware-markdown": {
@@ -15230,6 +15231,11 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
+    },
+    "urijs": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hof": "^13.2.2",
     "hof-build": "^2.0.0",
     "hof-component-date": "^1.4.0",
+    "hof-middleware": "^2.2.4",
     "hof-model": "^3.1.2",
     "hof-template-mixins": "4.2.0",
     "hof-theme-govuk": "^2.0.4",


### PR DESCRIPTION
**What**
Upgraded hof-middlware to v2.2.4
**Why**
Applications using this library could be vulnerable to a redirection exploit where an attacker can use a Home Office page to redirect someone to their malicious site
**How**
In hof-middleware ensure URLs are relative paths – i.e. they start with a single / character. Absolute URLs starting with // will be rejected.
**Test**
Unit test and manual url test