### PR TITLE
Brp-6 Including redirect to collection journey 

### DIFF
--- a/apps/not-arrived/behaviours/change-path.js
+++ b/apps/not-arrived/behaviours/change-path.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = superclass =>
+  class LetterRecieved extends superclass {
+    saveValues(req, res, next) {
+      if(req.form.values.collection === 'yes') {
+        res.statusCode = 302;
+        res.setHeader('Location', 'https://www.biometric-residence-permit.service.gov.uk/collection/where');
+        res.end();
+      }else{
+        super.saveValues(req, res, next);
+      }
+    }
+  };

--- a/apps/not-arrived/fields/letter-received.js
+++ b/apps/not-arrived/fields/letter-received.js
@@ -3,6 +3,24 @@
 const date = require('hof').components.date;
 
 module.exports = {
+  collection: {
+    mixin: 'radio-group',
+    validate: ['required'],
+    className: ['inline', 'form-group'],
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [
+      {
+        value: 'yes',
+        label: 'fields.collection.options.yes.label'
+      },
+      {
+        value: 'no',
+        label: 'fields.collection.options.no.label'
+      }
+    ]
+  },
   received: {
     validate: ['required'],
     className: ['inline', 'form-group'],

--- a/apps/not-arrived/index.js
+++ b/apps/not-arrived/index.js
@@ -7,22 +7,10 @@ module.exports = {
   steps: {
     '/collection': {
       next: '/letter-received',
-      fields:[
+      behaviours: [require('./behaviours/change-path')],
+      fields: [
         'collection'
-      ],
-      forks: [{
-        target: '/letter-received',
-        condition: {
-          field: 'collection',
-          value: 'no'
-        }
-      },{
-        target: '/collection/where',
-        condition: {
-          field: 'collection',
-          value: 'yes'
-        }
-      }]
+      ]
     },
     '/letter-received': {
       behaviours: [require('./behaviours/letter-received')],

--- a/apps/not-arrived/index.js
+++ b/apps/not-arrived/index.js
@@ -5,6 +5,25 @@ module.exports = {
   baseUrl: '/not-arrived',
   params: '/:action?',
   steps: {
+    '/collection': {
+      next: '/letter-received',
+      fields:[
+        'collection'
+      ],
+      forks: [{
+        target: '/letter-received',
+        condition: {
+          field: 'collection',
+          value: 'no'
+        }
+      },{
+        target: '/collection/where',
+        condition: {
+          field: 'collection',
+          value: 'yes'
+        }
+      }]
+    },
     '/letter-received': {
       behaviours: [require('./behaviours/letter-received')],
       fields: [
@@ -12,6 +31,7 @@ module.exports = {
         'delivery-date',
         'no-letter'
       ],
+      backLink: 'collection',
       next: '/same-address',
       forks: [{
         target: '/letter-not-received',

--- a/apps/not-arrived/translations/src/en/fields.json
+++ b/apps/not-arrived/translations/src/en/fields.json
@@ -1,4 +1,14 @@
 {
+  "collection": {
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
   "delivery-date": {
     "label": "Date",
     "legend": "Date on the letter",

--- a/apps/not-arrived/translations/src/en/pages.json
+++ b/apps/not-arrived/translations/src/en/pages.json
@@ -1,4 +1,7 @@
 {
+  "collection": {
+    "header": "Were you due to collect your document from the Post Office?"
+  },
   "letter-received": {
     "header": "Have you received a letter from the Home Office?",
     "subheader": "This letter may tell you:",

--- a/apps/not-arrived/views/collection.html
+++ b/apps/not-arrived/views/collection.html
@@ -1,0 +1,40 @@
+{{<layout}}
+  {{$step}}Step 1 of 5{{/step}}
+
+  {{$journeyHeader}}
+    {{#t}}journeys.delivery.header{{/t}}
+  {{/journeyHeader}}
+
+  {{$validationSummary}}
+    {{> partials-validation-summary}}
+  {{/validationSummary}}
+
+  {{$propositionHeader}}
+    {{> partials-navigation}}
+  {{/propositionHeader}}
+
+  {{$title}}
+    {{#t}}pages.collection.header{{/t}}
+  {{/title}}
+
+  {{$header}}
+    {{<partials-page-header}}
+      {{$page-header}}
+        {{#t}}pages.collection.header{{/t}}
+      {{/page-header}}
+    {{/partials-page-header}}
+  {{/header}}
+
+  {{$content}}
+  {{<partials-form}}
+  {{$form}}
+
+  {{#radio-group}}collection{{/radio-group}}
+  {{#input-submit}}continue{{/input-submit}}
+  {{/form}}
+
+  {{/partials-form}}
+  {{/content}}
+
+
+{{/layout}}

--- a/apps/not-arrived/views/collection.html
+++ b/apps/not-arrived/views/collection.html
@@ -1,5 +1,4 @@
 {{<layout}}
-  {{$step}}Step 1 of 5{{/step}}
 
   {{$journeyHeader}}
     {{#t}}journeys.delivery.header{{/t}}

--- a/apps/not-arrived/views/letter-received.html
+++ b/apps/not-arrived/views/letter-received.html
@@ -1,5 +1,5 @@
 {{<layout}}
-  {{$step}}Step 2 of 5{{/step}}
+  {{$step}}Step 1 of 5{{/step}}
 
   {{$journeyHeader}}
     {{#t}}journeys.delivery.header{{/t}}

--- a/apps/not-arrived/views/letter-received.html
+++ b/apps/not-arrived/views/letter-received.html
@@ -1,5 +1,5 @@
 {{<layout}}
-  {{$step}}Step 1 of 5{{/step}}
+  {{$step}}Step 2 of 5{{/step}}
 
   {{$journeyHeader}}
     {{#t}}journeys.delivery.header{{/t}}

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -6,7 +6,7 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
     Then I check 'collection-yes'
     Then I select 'Continue'
-    Then I should be redirected to the collection page showing 'From where were you asked to collect your BRP?'
+    Then I should be on the 'collection/where' page showing 'From where were you asked to collect your BRP?'
 
   Scenario: Letter not received from the home office
     Given I start the 'not-arrived' application journey

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -1,8 +1,18 @@
 @feature @not_arrived
 Feature: I should be able to log that my BRP has not arrived
 
+  Scenario: Due to collect the document from the postcode
+    Given I start the 'not-arrived' application journey
+    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-yes'
+    Then I select 'Continue'
+    Then I should be redirected to the collection page showing 'From where were you asked to collect your BRP?'
+
   Scenario: Letter not received from the home office
     Given I start the 'not-arrived' application journey
+    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-no'
+    Then I select 'Continue'
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
     Then I check 'received-no'
     Then I select 'Continue'
@@ -10,6 +20,9 @@ Feature: I should be able to log that my BRP has not arrived
 
   Scenario: BRP resent to same address
     Given I start the 'not-arrived' application journey
+    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-no'
+    Then I select 'Continue'
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
     Then I check 'received-yes'
     Then I fill the date 'delivery-date' with '24-5-2020'
@@ -31,6 +44,9 @@ Feature: I should be able to log that my BRP has not arrived
 
   Scenario: BRP resent to different address
     Given I start the 'not-arrived' application journey
+    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-no'
+    Then I select 'Continue'
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
     Then I check 'received-yes'
     Then I fill the date 'delivery-date' with '24-5-2020'

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -1,12 +1,12 @@
 @feature @not_arrived
 Feature: I should be able to log that my BRP has not arrived
-
+  
   Scenario: Due to collect the document from the postcode
     Given I start the 'not-arrived' application journey
     Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
     Then I check 'collection-yes'
     Then I select 'Continue'
-    Then I should be on the 'collection/where' page showing 'From where were you asked to collect your BRP?'
+    Then I should be redirected to the 'collection' journey on the 'where' page showing 'From where were you asked to collect your BRP?'
 
   Scenario: Letter not received from the home office
     Given I start the 'not-arrived' application journey

--- a/test/_features/step_definitions/steps.js
+++ b/test/_features/step_definitions/steps.js
@@ -68,13 +68,23 @@ Then('I enter a {string} date of birth for a {int} year old', async function (fi
 }.bind(World));
 
 Then('I should be on the {string} page showing {string}', async function (uri, heading) {
-  const redirect = '/collection/where';
   await this.page.waitForSelector('body', { timeout: 15000 });
-  expect(new URL(await this.page.url()).pathname).to.satisfy(
-    urlPathname => urlPathname === `${this.subApp}/${uri}` || redirect
-  );
+  expect(new URL(await this.page.url()).pathname).to.eql(`${this.subApp}/${uri}`);
   expect(await this.page.innerText('body')).to.include(heading);
 }.bind(World));
+
+Then(
+  'I should be redirected to the {string} journey on the {string} page showing {string}',
+  async function (subApp, uri, heading) {
+    this.subApp = subApp === 'base' ? '' : `/${subApp}`;
+    await this.page.goto(`${domain}${this.subApp}/${uri}`);
+    await this.page.waitForSelector('body', { timeout: 15000 });
+    expect(new URL(await this.page.url()).pathname).to.eql(
+      `${this.subApp}/${uri}`
+    );
+    expect(await this.page.innerText('body')).to.include(heading);
+  }.bind(World)
+);
 
 Then('I should see {string} on the page', async function (content) {
   await this.page.waitForSelector('body', { timeout: 15000 });

--- a/test/_features/step_definitions/steps.js
+++ b/test/_features/step_definitions/steps.js
@@ -73,6 +73,12 @@ Then('I should be on the {string} page showing {string}', async function (uri, h
   expect(await this.page.innerText('body')).to.include(heading);
 }.bind(World));
 
+Then('I should be redirected to the collection page showing {string}', async function (heading) {
+  await this.page.waitForSelector('body', { timeout: 15000 });
+  expect(await this.page.url()).to.include('https://www.biometric-residence-permit.service.gov.uk/collection/where');
+  expect(await this.page.innerText('body')).to.include(heading);
+}.bind(World));
+
 Then('I should see {string} on the page', async function (content) {
   await this.page.waitForSelector('body', { timeout: 15000 });
   expect(await this.page.innerText('body')).to.include(content);

--- a/test/_features/step_definitions/steps.js
+++ b/test/_features/step_definitions/steps.js
@@ -68,14 +68,11 @@ Then('I enter a {string} date of birth for a {int} year old', async function (fi
 }.bind(World));
 
 Then('I should be on the {string} page showing {string}', async function (uri, heading) {
+  const redirect = '/collection/where';
   await this.page.waitForSelector('body', { timeout: 15000 });
-  expect(new URL(await this.page.url()).pathname).to.eql(`${this.subApp}/${uri}`);
-  expect(await this.page.innerText('body')).to.include(heading);
-}.bind(World));
-
-Then('I should be redirected to the collection page showing {string}', async function (heading) {
-  await this.page.waitForSelector('body', { timeout: 15000 });
-  expect(await this.page.url()).to.include('https://www.biometric-residence-permit.service.gov.uk/collection/where');
+  expect(new URL(await this.page.url()).pathname).to.satisfy(
+    urlPathname => urlPathname === `${this.subApp}/${uri}` || redirect
+  );
   expect(await this.page.innerText('body')).to.include(heading);
 }.bind(World));
 


### PR DESCRIPTION
**What** 
Including a question asking the customer 'Were you due to collect your document form the Post Office?'. If so, they can be redirected to the "Collections" journey. 

**Why**
So that the customer doesn't have to wait to be redirected by a decision maker after 5 days+.

**How** 
The landing URI has been changed to not-arrived/collection with an option which redirects to the /collection URI if the 'yes' option is chosen, otherwise continues the journey as normal. 

**Testing**
Adapted acceptance test to check validation fails and run linting tests.