### PR TITLE
BRP-6

### DIFF
--- a/apps/not-arrived/behaviours/change-path.js
+++ b/apps/not-arrived/behaviours/change-path.js
@@ -4,8 +4,7 @@ module.exports = superclass =>
   class LetterRecieved extends superclass {
     saveValues(req, res, next) {
       if(req.form.values.collection === 'yes') {
-        res.statusCode = 302;
-        res.setHeader('Location', 'https://www.biometric-residence-permit.service.gov.uk/collection/where');
+        res.redirect(302, `${req.headers.origin}/collection/where`);
         res.end();
       }else{
         super.saveValues(req, res, next);

--- a/apps/not-arrived/index.js
+++ b/apps/not-arrived/index.js
@@ -5,7 +5,7 @@ module.exports = {
   baseUrl: '/not-arrived',
   params: '/:action?',
   steps: {
-    '/collection': {
+    '/post-office-collect': {
       next: '/letter-received',
       behaviours: [require('./behaviours/change-path')],
       fields: [
@@ -19,7 +19,7 @@ module.exports = {
         'delivery-date',
         'no-letter'
       ],
-      backLink: 'collection',
+      backLink: 'post-office-collect',
       next: '/same-address',
       forks: [{
         target: '/letter-not-received',

--- a/apps/not-arrived/translations/src/en/pages.json
+++ b/apps/not-arrived/translations/src/en/pages.json
@@ -1,5 +1,5 @@
 {
-  "collection": {
+  "post-office-collect": {
     "header": "Were you due to collect your document from the Post Office?"
   },
   "letter-received": {

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -16,7 +16,7 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
     Then I check 'received-no'
     Then I select 'Continue'
-    Then I should be on the 'letter-not-received' page ggshowing 'Contact us'
+    Then I should be on the 'letter-not-received' page showing 'Contact us'
 
   Scenario: BRP resent to same address
     Given I start the 'not-arrived' application journey

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -3,24 +3,24 @@ Feature: I should be able to log that my BRP has not arrived
   
   Scenario: Due to collect the document from the postcode
     Given I start the 'not-arrived' application journey
-    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
     Then I check 'collection-yes'
     Then I select 'Continue'
     Then I should be redirected to the 'collection' journey on the 'where' page showing 'From where were you asked to collect your BRP?'
 
   Scenario: Letter not received from the home office
     Given I start the 'not-arrived' application journey
-    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
     Then I check 'collection-no'
     Then I select 'Continue'
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
     Then I check 'received-no'
     Then I select 'Continue'
-    Then I should be on the 'letter-not-received' page showing 'Contact us'
+    Then I should be on the 'letter-not-received' page ggshowing 'Contact us'
 
   Scenario: BRP resent to same address
     Given I start the 'not-arrived' application journey
-    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
     Then I check 'collection-no'
     Then I select 'Continue'
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
@@ -44,7 +44,7 @@ Feature: I should be able to log that my BRP has not arrived
 
   Scenario: BRP resent to different address
     Given I start the 'not-arrived' application journey
-    Then I should be on the 'collection' page showing 'Were you due to collect your document from the Post Office?'
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
     Then I check 'collection-no'
     Then I select 'Continue'
     Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'


### PR DESCRIPTION
### **What**

1. Updating step name from /collection so as not to be confused with the collection journey. Changed to _post-office-collect_ .
2. When loading the not-arrived app and answering "Yes" to the first question (Were you due to collect the document from the post office?) the service redirects to the live URL regardless of the environment. Change-path behaviour was hard-coded to redirect to the live URL. This has been updated to use a relative path.
3. Also noticed a typo in one of the acceptance test which has been corrected.

### **Why**

1. To avoid confusion.
2. Removing a bug in development mode.
3. Get acceptance tests working without errors.

### **How**

1. Changed step name in journey index and translations files. Relevant acceptance tests have also been edited to reflect the changes.
2. change-path.js behaviour edited to redirect (instead of setHeader - for readability) to relative path. 

### **Testing**
Unit, acceptance and lint tests run locally.