### PR TITLE
Added notUrl check to Full Name, Passport Number, BRP Number etc

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,4 +14,17 @@ ignore:
     - hof > browserify > shell-quote:
         reason: No update currently available
         expires: '2022-09-18T12:35:24.867Z'
+  SNYK-JS-CACHEDPATHRELATIVE-2342653:
+    - hof > browserify > cached-path-relative:
+        reason: No update currently available
+        expires: '2022-02-20T10:38:20.144Z'
+    - hof > browserify > module-deps > cached-path-relative:
+        reason: No update currently available
+        expires: '2022-02-20T10:38:20.144Z'
+    - browserify > cached-path-relative:
+        reason: No update currently available
+        expires: '2022-02-20T10:38:20.144Z'
+    - browserify > module-deps > cached-path-relative:
+        reason: No update currently available
+        expires: '2022-02-20T10:38:20.144Z'
 patch: {}

--- a/apps/collection/fields/index.js
+++ b/apps/collection/fields/index.js
@@ -75,7 +75,7 @@ module.exports = {
     validate: ['required', 'before']
   }),
   fullname: {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   'date-of-birth': date('date-of-birth', {
     validate: ['required', 'before']
@@ -87,6 +87,6 @@ module.exports = {
     hint: 'fields.nationality.hint'
   },
   passport: {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   }
 };

--- a/apps/collection/translations/src/en/validation.json
+++ b/apps/collection/translations/src/en/validation.json
@@ -10,7 +10,8 @@
     "email": "Enter your email in the correct format for example, name@domain.com"
   },
   "fullname": {
-    "required": "Enter your full name"
+    "required": "Enter your full name",
+    "notUrl": "Full name must not be a URL"
   },
   "date-of-birth": {
     "required": "Enter your date of birth",
@@ -45,7 +46,8 @@
     "equal": "Please pick a nationality from the list"
   },
   "passport": {
-    "required": "What is your passport number?"
+    "required": "What is your passport number?",
+    "notUrl": "Passport Number must not be a URL"
   },
   "org-help": {
     "required": "Did you have help completing this form?"

--- a/apps/collection/translations/src/en/validation.json
+++ b/apps/collection/translations/src/en/validation.json
@@ -53,7 +53,8 @@
     "required": "Did you have help completing this form?"
   },
   "rep-name": {
-    "required": "What is the name of the person who helped you complete this form?"
+    "required": "What is the name of the person who helped you complete this form?",
+    "notUrl": "Full name must not be a URL"
   },
   "org-type": {
     "required": "Who has helped you fill in this form?"

--- a/apps/common/fields/organisation-details.js
+++ b/apps/common/fields/organisation-details.js
@@ -17,7 +17,7 @@ module.exports = {
     ]
   },
   'rep-name': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     dependent: {
       field: 'org-help',
       value: 'yes'

--- a/apps/common/fields/personal-details.js
+++ b/apps/common/fields/personal-details.js
@@ -4,7 +4,7 @@ const date = require('hof').components.date;
 
 module.exports = {
   fullname: {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   'date-of-birth': date('date-of-birth', {
     validate: ['required', 'before'],
@@ -18,7 +18,7 @@ module.exports = {
     hint: 'fields.nationality.hint'
   },
   passport: {
-    validate: 'required'
+    validate: ['required', 'notUrl']
   },
   'brp-card': {
     hint: 'fields.brp-card.hint'

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -30,7 +30,8 @@
     "required": "Did you have help completing this form?"
   },
   "rep-name": {
-    "required": "What is the name of the person who helped you complete this form?"
+    "required": "What is the name of the person who helped you complete this form?",
+    "notUrl": "Full name must not be a URL"
   },
   "rep-email": {
     "required": "What is the contact e-mail address of the person who helped you complete this form?",

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -38,5 +38,9 @@
   },
   "org-type": {
     "required": "Who has helped you fill in this form?"
+  },
+  "fullname": {
+    "required": "Enter your full name",
+    "notUrl": "Full name must not be a URL"
   }
 }

--- a/apps/lost-stolen/fields/personal-details.js
+++ b/apps/lost-stolen/fields/personal-details.js
@@ -10,6 +10,9 @@ const beforeTodayValidator = {
 };
 
 module.exports = {
+  fullname: {
+    validate: 'notUrl'
+  },
   'brp-card': {
     validate: ['required', {type: 'regex', arguments: /^[a-z][a-z](\d|X)\d{6}$/gi }],
     formatter: ['uppercase'],

--- a/apps/lost-stolen/translations/src/en/validation.json
+++ b/apps/lost-stolen/translations/src/en/validation.json
@@ -4,7 +4,8 @@
     "email": "Enter your email in the correct format for example, name@domain.com"
   },
   "fullname": {
-    "required": "Enter your full name"
+    "required": "Enter your full name",
+    "notUrl": "Full name must not be a URL"
   },
   "date-of-birth": {
     "required": "Enter your date of birth",

--- a/apps/lost-stolen/translations/src/en/validation.json
+++ b/apps/lost-stolen/translations/src/en/validation.json
@@ -36,7 +36,8 @@
     "required": "Did someone help you complete this form?"
   },
   "rep-name": {
-    "required": "What is the name of the person who helped you complete this form?"
+    "required": "What is the name of the person who helped you complete this form?",
+    "notUrl": "Full name must not be a URL"
   },
   "org-type": {
     "required": "Who has helped you fill in this form?"

--- a/apps/not-arrived/translations/src/en/validation.json
+++ b/apps/not-arrived/translations/src/en/validation.json
@@ -19,7 +19,8 @@
     "equal": "Please pick a nationality from the list"
   },
   "passport": {
-    "required": "What is your passport number?"
+    "required": "What is your passport number?",
+    "notUrl": "Passport Number must not be a URL"
   },
   "country": {
     "required": "Tell us where you are"

--- a/apps/someone-else/fields/arrange.js
+++ b/apps/someone-else/fields/arrange.js
@@ -4,7 +4,7 @@ const date = require('hof').components.date;
 
 module.exports = {
   'someone-else-fullname': {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   },
   'someone-else-date': date('someone-else-date', {
     validate: [
@@ -26,6 +26,6 @@ module.exports = {
     ]
   },
   'someone-else-id-number': {
-    validate: ['required']
+    validate: ['required', 'notUrl']
   }
 };

--- a/apps/someone-else/translations/src/en/validation.json
+++ b/apps/someone-else/translations/src/en/validation.json
@@ -4,7 +4,8 @@
     "email": "Enter your email in the correct format for example, name@domain.com"
   },
   "fullname": {
-    "required": "Enter your full name"
+    "required": "Enter your full name",
+    "notUrl": "Full name must not be a URL"
   },
   "date-of-birth": {
     "required": "Enter your date of birth",
@@ -24,7 +25,8 @@
     "before": "The person nominated to collect your BRP must be over 18 years old"
   },
   "someone-else-fullname": {
-    "required": "What is the nominated person's full name?"
+    "required": "What is the nominated person's full name?",
+    "notUrl": "The nominated person's name must not be a URL"
   },
   "someone-else-nationality": {
     "required": "What is the nominated person's nationality?",
@@ -35,7 +37,8 @@
   },
   "someone-else-id-number": {
     "required": "What is the nominated person's identity document number?",
-    "brp-valid": "BRP number must be in the correct format; for example, ‘ZUX123456 or ZU1234567’"
+    "brp-valid": "BRP number must be in the correct format; for example, ‘ZUX123456 or ZU1234567’",
+    "notUrl": "The nominatated person's identity document number must not be a URL"
   },
   "someone-else-reason-radio": {
     "required": "Select a reason why you couldn't collect your BRP"

--- a/apps/someone-else/translations/src/en/validation.json
+++ b/apps/someone-else/translations/src/en/validation.json
@@ -48,7 +48,8 @@
     "equal": "Please pick a nationality from the list"
   },
   "passport": {
-    "required": "What is your passport number?"
+    "required": "What is your passport number?",
+    "notUrl": "Passport number must not be a URL"
   },
   "org-help": {
     "required": "Did you have help completing this form?"

--- a/test/_features/brp/collection_form.feature
+++ b/test/_features/brp/collection_form.feature
@@ -148,3 +148,44 @@ Feature: A user should access the collection problem service and be able to log 
     Then I fill 'email' with 'test@test.test'
     Then I select 'Continue'
     Then I should be on the 'confirm' page showing 'Check the details you have provided'
+
+
+  @noBrp
+  Scenario: collection application to be contacted via email
+    Given I start the 'collection' application journey
+    Then I should be on the 'where' page showing 'From where were you asked to collect your BRP?'
+    Then I check 'collection-where-radio-Sponsor'
+    Then I fill the date 'collection-date' with '30-5-2021'
+    Then I select 'Continue'
+    Then I should be on the 'reasons' page showing 'Why couldn\'t you collect your BRP?'
+    Then I check 'reason-radio-no-brp'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'Ronald Testman'
+    Then I fill the date 'date-of-birth' with '24-5-1990'
+    Then I fill 'nationality' with 'British Overseas Citizen'
+    Then I fill 'passport' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+    Then I fill 'email' with 'test@test.test'
+    Then I select 'Continue'
+    Then I should be on the 'confirm' page showing 'Check the details you have provided'
+
+  @validation
+  Scenario: Collection application Personal Details not a URL validation
+    Given I start the 'collection' application journey
+    Then I should be on the 'where' page showing 'From where were you asked to collect your BRP?'
+    Then I check 'collection-where-radio-Sponsor'
+    Then I fill the date 'collection-date' with '30-5-2021'
+    Then I select 'Continue'
+    Then I should be on the 'reasons' page showing 'Why couldn\'t you collect your BRP?'
+    Then I check 'reason-radio-no-brp'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'www.google.com'
+    Then I fill the date 'date-of-birth' with '24-5-1990'
+    Then I fill 'nationality' with 'British Overseas Citizen'
+    Then I fill 'passport' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'Full name must not be a URL' on the page
+    And I should see 'Passport Number must not be a URL' on the page

--- a/test/_features/brp/correct_mistakes.feature
+++ b/test/_features/brp/correct_mistakes.feature
@@ -113,3 +113,57 @@ Feature: A user should access the correct mistakes service and be able to log an
       Then I select 'Continue'
       Then I should see 'Enter your BRP number in the correct format; for example, ‘ZUX123456 or ZU1234567’' on the page
 
+    @validation
+    Scenario: Correct Mistakes Personal Details not a URL validation
+      Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'location' page showing 'Where did you apply for your visa?'
+      Then I check 'location-applied-no'
+      Then I select 'Continue'
+      Then I should be on the 'about-error' page showing 'What’s the problem with your BRP?'
+      Then I check 'first-name-error-checkbox'
+      Then I fill 'first-name-error' with 'Ronald'
+      Then I select 'Continue'
+      Then I should be on the 'uk-address' page showing 'Is there a suitable UK address we can deliver your BRP to?'
+      Then I check 'uk-address-radio-yes'
+      Then I fill 'uk-address-house-number' with '17'
+      Then I fill 'uk-address-street' with 'test avenue'
+      Then I fill 'uk-address-town' with 'Rotherham'
+      Then I fill 'uk-address-county' with 'South Yorkshire'
+      Then I fill 'uk-address-postcode' with 'RH17 5BE'
+      Then I select 'Continue'
+      Then I should be on the 'personal-details' page showing 'How do your personal details appear on your BRP?'
+      Then I fill 'fullname' with 'www.google.com'
+      Then I fill the date 'date-of-birth' with '30-05-1990'
+      Then I fill 'nationality' with 'Namibia'
+      Then I fill 'brp-card' with 'ZR000123'
+      Then I select 'Continue'
+      Then I should see 'Full name must not be a URL' on the page
+
+    @validation
+    Scenario: Correct Mistakes Representative Personal Details not a URL validation
+      Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'location' page showing 'Where did you apply for your visa?'
+      Then I check 'location-applied-yes'
+      Then I select 'Continue'
+      Then I should be on the 'about-error' page showing 'What’s the problem with your BRP?'
+      Then I check 'last-name-error-checkbox'
+      Then I fill 'last-name-error' with 'Testman'
+      Then I select 'Continue'
+      Then I should be on the 'same-address' page showing 'Is your address the same as the address on the delivery letter?'
+      Then I check 'same-address-radio-yes'
+      Then I select 'Continue'
+      Then I should be on the 'personal-details' page showing 'How do your personal details appear on your BRP?'
+      Then I fill 'fullname' with 'Ronald Testman'
+      Then I fill the date 'date-of-birth' with '30-05-1990'
+      Then I fill 'nationality' with 'Namibia'
+      Then I fill 'brp-card' with 'XR1000123'
+      Then I select 'Continue'
+      Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+      Then I fill 'email' with 'test@dtest.testemail'
+      Then I select 'Continue'
+      Then I should be on the 'confirm' page showing 'Check the details you have provided'
+      Then I check 'org-help-yes'
+      Then I should see 'We will attempt to contact the BRP holder directly. We will only use these details to contact you if needed.' on the page
+      Then I fill 'rep-name' with 'www.google.com'
+      Then I submit the application
+      Then I should see 'Full name must not be a URL' on the page

--- a/test/_features/brp/lost_stolen.feature
+++ b/test/_features/brp/lost_stolen.feature
@@ -39,3 +39,43 @@ Feature: A user should be able to log a lost or stolen BRP
     Then I fill 'email' with 'test@dtest.testemail'
     Then I select 'Continue'
     Then I should be on the 'confirm' page showing 'Check the details you have provided'
+
+  @validation
+  Scenario: Lost or Stolen application Personal Details not a URL validation
+    Given I start the 'lost-stolen' application journey
+    Then I should be on the 'where' page showing 'Where are you now?'
+    Then I check 'inside-uk-no'
+    Then I fill 'country' with 'Bahamas'
+    Then I select 'Continue'
+    Then I should be on the 'date-lost' page showing 'When did you realise you no longer had your BRP?'
+    Then I fill the date 'date-lost' with '30-05-2021'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'Full name must not be a URL' on the page
+
+  @validation
+    Scenario: Lost or Stolen application Representative Personal Details not a URL validation
+      Given I start the 'lost-stolen' application journey
+      Then I should be on the 'where' page showing 'Where are you now?'
+      Then I check 'inside-uk-yes'
+      Then I select 'Continue'
+      Then I should be on the 'date-lost' page showing 'When did you realise you no longer had your BRP?'
+      Then I fill the date 'date-lost' with '30-05-2021'
+      Then I select 'Continue'
+      Then I should be on the 'personal-details' page showing 'What are your personal details?'
+      Then I fill 'fullname' with 'Ronald Testman'
+      Then I fill the date 'date-of-birth' with '30-05-1990'
+      Then I fill 'nationality' with 'Namibia'
+      Then I fill 'brp-card' with 'ZRX000123'
+      Then I select 'Continue'
+      Then I should be on the 'contact-details' page showing 'How should we contact you to tell you what to do next?'
+      Then I fill 'email' with 'test@dtest.testemail'
+      Then I select 'Continue'
+      Then I should be on the 'confirm' page showing 'Check the details you have provided'
+      Then I check 'org-help-yes'
+      Then I should see 'We will attempt to contact the BRP holder directly. We will only use these details to contact you if needed.' on the page
+      Then I fill 'rep-name' with 'www.google.com'
+      Then I submit the application
+      Then I should see 'Full name must not be a URL' on the page

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -73,3 +73,49 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should see 'Delivery details' on the page
     Then I should see 'Personal details' on the page
     Then I should see 'Are you completing this form on behalf of the BRP holder?' on the page
+
+  @validation
+  Scenario: Not Arrived application Personal Details not a URL validation
+    Given I start the 'not-arrived' application journey
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-no'
+    Then I select 'Continue'
+    Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
+    Then I check 'received-yes'
+    Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I select 'Continue'
+    Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
+    Then I check 'address-match-yes'
+    Then I fill 'delivery-details' text area with 'Watch out for the dog!'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'www.google.com'
+    Then I fill 'passport' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'Full name must not be a URL' on the page
+    And I should see 'Passport Number must not be a URL' on the page
+
+  @validation
+  Scenario: Not Arrived application Representative Personal Details not a URL validation
+    Given I start the 'not-arrived' application journey
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-no'
+    Then I select 'Continue'
+    Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
+    Then I check 'received-yes'
+    Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I select 'Continue'
+    Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
+    Then I check 'address-match-yes'
+    Then I fill 'delivery-details' text area with 'Watch out for the dog!'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'Ronald Testman'
+    Then I fill the date 'date-of-birth' with '24-5-1990'
+    Then I fill 'nationality' with 'British Overseas Citizen'
+    Then I fill 'passport' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+    Then I fill 'email' with 'test@test.test'
+    Then I select 'Continue'
+    Then I should be on the 'confirm' page showing 'Check the details you have provided'

--- a/test/_features/brp/someone_else.feature
+++ b/test/_features/brp/someone_else.feature
@@ -74,3 +74,67 @@ Feature: I want someone else to collect my BRP
     Then I fill 'passport' with '1234JA2345'
     Then I select 'Continue'
     Then I should see the 'If you are over 18 years old you can collect your own BRP' error
+
+  @validation
+  Scenario: Someone Else Application Nominated Persons Personal Details not a URL validation
+    Given I start the 'someone-else' application journey
+    Then I should be on the 'arrange' page showing 'Who would you like to nominate?'
+    Then I fill 'someone-else-fullname' with 'www.google.com'
+    Then I fill 'someone-else-id-number' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'The nominatated person\'s identity document number must not be a URL' on the page
+    And I should see 'The nominated person\'s name must not be a URL' on the page
+
+  @validation
+  Scenario: Someone Else Application Personal Details not a URL validation
+    Given I start the 'someone-else' application journey
+    Then I should be on the 'arrange' page showing 'Who would you like to nominate?'
+    Then I fill 'someone-else-fullname' with 'Donald Testman'
+    Then I fill the date 'someone-else-date' with '24-5-1990'
+    Then I fill 'someone-else-nationality' with 'British Overseas Citizen'
+    Then I check 'someone-else-id-type-eu-national-id'
+    Then I fill 'someone-else-id-number' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'reason' page showing 'Why do you need someone else to collect your BRP?'
+    Then I check 'someone-else-reason-radio-incapable'
+    Then I fill 'incapable-details' text area with 'test input'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'www.google.com'
+    Then I fill 'passport' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'Full name must not be a URL' on the page
+    And I should see 'Passport number must not be a URL' on the page
+
+  @validation
+  Scenario: Someone Else Application Representative Personal Details not a URL validation
+    Given I start the 'someone-else' application journey
+    Then I should be on the 'arrange' page showing 'Who would you like to nominate?'
+    Then I fill 'someone-else-fullname' with 'Donald Testman'
+    Then I fill the date 'someone-else-date' with '24-5-1990'
+    Then I fill 'someone-else-nationality' with 'British Overseas Citizen'
+    Then I check 'someone-else-id-type-eu-national-id'
+    Then I fill 'someone-else-id-number' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'reason' page showing 'Why do you need someone else to collect your BRP?'
+    Then I check 'someone-else-reason-radio-incapable'
+    Then I fill 'incapable-details' text area with 'test input'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'Ronald Testman'
+    Then I fill the date 'date-of-birth' with '24-5-1990'
+    Then I fill 'nationality' with 'British Overseas Citizen'
+    Then I fill 'passport' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+    Then I fill 'email' with 'test@test.test'
+    Then I select 'Continue'
+    Then I should be on the 'confirm' page showing 'Check the details you have provided'
+    Then I should see 'Details of person nominated to collect BRP' on the page
+    Then I should see 'Your details' on the page
+    Then I should see 'Are you completing this form on behalf of the BRP holder?' on the page
+    Then I check 'org-help-yes'
+    Then I should see 'We will attempt to contact the BRP holder directly. We will only use these details to contact you if needed.' on the page
+    Then I fill 'rep-name' with 'www.google.com'
+    Then I submit the application
+    Then I should see 'Full name must not be a URL' on the page

--- a/test/_unit/apps/common/validation/validation.spec.js
+++ b/test/_unit/apps/common/validation/validation.spec.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const Controller = require('hof').controller;
+
+//We don't need an actual controller, so just create a dummy
+const DummyController = superclass => class DummyController extends superclass {
+  configure(req, res, next) {
+    super.configure(req, res, next);
+  }
+};
+
+describe('apps/commong/validation', () => {
+  let controller;
+  let req;
+  let res;
+
+  'use strict';
+  
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+
+    req.form.options = {};
+
+    const MyDummyController = DummyController(Controller);
+    controller = new MyDummyController({ template: 'index', route: '/index' });
+  });
+
+  describe('configure', () => {
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      req.form.options.fields = {
+        'ImAURL': {
+          validate: 'notUrl'
+        }
+      };
+
+      sandbox.stub(Controller.prototype, 'configure').yieldsAsync();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    describe('validation', () => {
+      it('notUrl should not accept a URL input', () => {
+        req.form.values['ImAURL'] = 'www.google.com';
+        
+        controller._validate(req, res, err => {
+          err['ImAURL'].should.be.an.instanceof(controller.ValidationError);
+          err['ImAURL'].should.have.property('type').and.equal('notUrl');
+        });
+      });
+    });
+  
+  });
+});

--- a/test/_unit/apps/common/validation/validation.spec.js
+++ b/test/_unit/apps/common/validation/validation.spec.js
@@ -2,8 +2,8 @@
 
 const Controller = require('hof').controller;
 
-//We don't need an actual controller, so just create a dummy
-const DummyController = superclass => class DummyController extends superclass {
+// We don't need an actual controller, so just create a dummy
+const DummyController = class DummyControllerBase extends Controller {
   configure(req, res, next) {
     super.configure(req, res, next);
   }
@@ -15,15 +15,14 @@ describe('apps/commong/validation', () => {
   let res;
 
   'use strict';
-  
+
   beforeEach(() => {
     req = reqres.req();
     res = reqres.res();
 
     req.form.options = {};
 
-    const MyDummyController = DummyController(Controller);
-    controller = new MyDummyController({ template: 'index', route: '/index' });
+    controller = new DummyController({ template: 'index', route: '/index' });
   });
 
   describe('configure', () => {
@@ -32,7 +31,7 @@ describe('apps/commong/validation', () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       req.form.options.fields = {
-        'ImAURL': {
+        ImAURL: {
           validate: 'notUrl'
         }
       };
@@ -46,14 +45,12 @@ describe('apps/commong/validation', () => {
 
     describe('validation', () => {
       it('notUrl should not accept a URL input', () => {
-        req.form.values['ImAURL'] = 'www.google.com';
-        
+        req.form.values.ImAURL = 'www.google.com';
         controller._validate(req, res, err => {
-          err['ImAURL'].should.be.an.instanceof(controller.ValidationError);
-          err['ImAURL'].should.have.property('type').and.equal('notUrl');
+          err.ImAURL.should.be.an.instanceof(controller.ValidationError);
+          err.ImAURL.should.have.property('type').and.equal('notUrl');
         });
       });
     });
-  
   });
 });


### PR DESCRIPTION
What?
Added notUrl check to Full Name, Passport Number, BRP Number and Nominated Persons ID Number

Why?
To ensure malicious website URLs do not get sent in the emails that are generated by the backend processes

How?
notUrl validation rule is used

Testing?
Tested manually. Also all existing unit tests and automation tests are passing. 

Screenshots (optional)
N/A

Anything Else?
N/A