### PR TITLE
BRP-35-fix-optional

### DIFF
--- a/apps/lost-stolen/fields/personal-details.js
+++ b/apps/lost-stolen/fields/personal-details.js
@@ -14,7 +14,7 @@ module.exports = {
     validate: 'notUrl'
   },
   'brp-card': {
-    validate: ['required', {type: 'regex', arguments: /^[a-z][a-z](\d|X)\d{6}$/gi }],
+    validate: [{type: 'regex', arguments: /(^[a-z][a-z](\d|X)\d{6}$)|(^$)/gi }],
     formatter: ['uppercase'],
     hint: 'fields.brp-card.hint'
   },


### PR DESCRIPTION
Fix the brp validation so that entering a BRP number is optional on the lost-stolen route on the personal details page.