### PR TITLE
BRP-53-missing-error-details

### DIFF
--- a/services/email/templates/caseworker/html/error.mus
+++ b/services/email/templates/caseworker/html/error.mus
@@ -200,6 +200,28 @@
                         <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{conditions-error}}</p></td>
                       </tr>
                     {{/conditions-error}}
+
+                    {{#length-of-stay-error}}
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.length-of-stay-error-checkbox.label{{/t}}</p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{length-of-stay-error}}</p></td>
+                      </tr>
+                    {{/length-of-stay-error}}
+
+                    {{#biographics-error}}
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.biographics-error-checkbox.label{{/t}}</p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{biographics-error}}</p></td>
+                      </tr>
+                    {{/biographics-error}}
+
+                    {{#BRP-issue-error}}
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.BRP-issue-error-checkbox.label{{/t}}</p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{BRP-issue-error}}</p></td>
+                      </tr>
+                    {{/BRP-issue-error}}
+
                   </table>
 
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Contact details</p>

--- a/services/email/templates/caseworker/plain/error.mus
+++ b/services/email/templates/caseworker/plain/error.mus
@@ -96,6 +96,21 @@
     {{conditions-error}}
   {{/conditions-error}}
 
+  {{#length-of-stay-error}}
+    {{#t}}fields.length-of-stay-error-checkbox.label{{/t}}
+    {{length-of-stay-error}}
+  {{/length-of-stay-error}}
+
+  {{#biographics-error}}
+    {{#t}}fields.biographics-error-checkbox.label{{/t}}
+    {{biographics-error}}
+  {{/biographics-error}}
+
+  {{#BRP-issue-error}}
+    {{#t}}fields.BRP-issue-error-checkbox.label{{/t}}
+    {{BRP-issue-error}}
+  {{/BRP-issue-error}}
+
   Contact details
 
   {{#contact-address-street}}


### PR DESCRIPTION
Error details were missing from some BRP submissions

Discovered this was on the recently added new fields. Updated email templates to properly capture this information.