### PR TITLE
HOFF-223: update BRP to latest version of HOF and review any URL inputs

### DIFF
--- a/apps/collection/translations/src/en/validation.json
+++ b/apps/collection/translations/src/en/validation.json
@@ -58,5 +58,8 @@
   },
   "org-type": {
     "required": "Who has helped you fill in this form?"
+  },
+  "phone": {
+    "notUrl": "Phone number must not be a URL"
   }
 }

--- a/apps/common/fields/contact-details.js
+++ b/apps/common/fields/contact-details.js
@@ -13,7 +13,7 @@ module.exports = {
     toggle: 'address-group'
   },
   'contact-address-house-number': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-house-number.label',
     dependent: {
       value: 'true',
@@ -21,7 +21,7 @@ module.exports = {
     }
   },
   'contact-address-street': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-street.label',
     dependent: {
       value: 'true',
@@ -29,7 +29,7 @@ module.exports = {
     }
   },
   'contact-address-town': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-town.label',
     dependent: {
       value: 'true',
@@ -37,14 +37,18 @@ module.exports = {
     }
   },
   'contact-address-county': {
+    validate: ['notUrl'],
     label: 'fields.address-county.label'
   },
   'contact-address-postcode': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-postcode.label',
     dependent: {
       value: 'true',
       field: 'use-address'
     }
+  },
+  phone:{
+    validate: ['notUrl']
   }
 };

--- a/apps/common/fields/contact-details.js
+++ b/apps/common/fields/contact-details.js
@@ -48,7 +48,7 @@ module.exports = {
       field: 'use-address'
     }
   },
-  phone:{
+  phone: {
     validate: ['notUrl']
   }
 };

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -15,16 +15,23 @@
     "required": "A case ID number is required for your BRP to be sent to a different address"
   },
   "contact-address-house-number": {
-    "required": "Enter your building name or number"
+    "required": "Enter your building name or number",
+    "notUrl": "Building name or number must not be a URL"
   },
   "contact-address-street": {
-    "required": "Enter your street"
+    "required": "Enter your street",
+    "notUrl": "Street must not be a URL"
   },
   "contact-address-town": {
-    "required": "Enter the town or city"
+    "required": "Enter the town or city",
+    "notUrl": "Town or City must not be a URL"
+  },
+  "contact-address-county": {
+    "notUrl": "County must not be a URL"
   },
   "contact-address-postcode": {
-    "required": "Enter the postcode"
+    "required": "Enter the postcode",
+    "notUrl": "Postcode must not be a URL"
   },
   "org-help": {
     "required": "Did you have help completing this form?"

--- a/apps/common/translations/src/en/validation.json
+++ b/apps/common/translations/src/en/validation.json
@@ -12,7 +12,8 @@
     "required": "Enter the postcode"
   },
   "case-id": {
-    "required": "A case ID number is required for your BRP to be sent to a different address"
+    "required": "A case ID number is required for your BRP to be sent to a different address",
+    "notUrl": "Case ID number must not be a URL"
   },
   "contact-address-house-number": {
     "required": "Enter your building name or number",

--- a/apps/correct-mistakes/fields/about-error.js
+++ b/apps/correct-mistakes/fields/about-error.js
@@ -41,7 +41,7 @@ module.exports = {
     toggle: 'birth-place-error-container'
   },
   'birth-place-error': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     dependent: {
       field: 'birth-place-error-checkbox',
       value: 'true'
@@ -66,7 +66,7 @@ module.exports = {
     toggle: 'sponsor-details-error-container'
   },
   'sponsor-details-error': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     dependent: {
       field: 'sponsor-details-error-checkbox',
       value: 'true'
@@ -109,7 +109,7 @@ module.exports = {
     toggle: 'national-insurance-error-container'
   },
   'national-insurance-error': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     dependent: {
       field: 'national-insurance-error-checkbox',
       value: 'true'

--- a/apps/correct-mistakes/fields/personal-details.js
+++ b/apps/correct-mistakes/fields/personal-details.js
@@ -5,5 +5,8 @@ module.exports = {
     validate: ['required', {type: 'regex', arguments: /^[a-z][a-z](\d|X)\d{6}$/gi }],
     formatter: ['uppercase'],
     hint: 'fields.brp-card.hint'
+  },
+  phone: {
+    validate: ['notUrl']
   }
 };

--- a/apps/correct-mistakes/fields/same-address.js
+++ b/apps/correct-mistakes/fields/same-address.js
@@ -33,7 +33,7 @@ module.exports = {
     }
   },
   'same-address-town': {
-    validate: ['required','notUrl'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-town.label',
     dependent: {
       value: 'no',

--- a/apps/correct-mistakes/fields/same-address.js
+++ b/apps/correct-mistakes/fields/same-address.js
@@ -17,7 +17,7 @@ module.exports = {
     ]
   },
   'same-address-house-number': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-house-number.label',
     dependent: {
       value: 'no',
@@ -25,7 +25,7 @@ module.exports = {
     }
   },
   'same-address-street': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-street.label',
     dependent: {
       value: 'no',
@@ -33,7 +33,7 @@ module.exports = {
     }
   },
   'same-address-town': {
-    validate: ['required'],
+    validate: ['required','notUrl'],
     label: 'fields.address-town.label',
     dependent: {
       value: 'no',
@@ -41,10 +41,15 @@ module.exports = {
     }
   },
   'same-address-county': {
-    label: 'fields.address-county.label'
+    validate: ['notUrl'],
+    label: 'fields.address-county.label',
+    dependent: {
+      value: 'no',
+      field: 'same-address-radio'
+    }
   },
   'same-address-postcode': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-postcode.label',
     dependent: {
       value: 'no',

--- a/apps/correct-mistakes/translations/src/en/validation.json
+++ b/apps/correct-mistakes/translations/src/en/validation.json
@@ -22,16 +22,23 @@
     "required": "Enter the postcode"
   },
   "same-address-house-number": {
-    "required": "Enter your building name or number"
+    "required": "Enter your building name or number",
+    "notUrl": "Building name or number must not be a URL"
   },
   "same-address-street": {
-    "required": "Enter your street"
+    "required": "Enter your street",
+    "notUrl": "Street must not be a URL"
   },
   "same-address-town": {
-    "required": "Enter the town or city"
+    "required": "Enter the town or city",
+    "notUrl": "Town or City must not be a URL"
+  },
+  "same-address-county": {
+    "notUrl": "County must not be a URL"
   },
   "same-address-postcode": {
-    "required": "Enter the postcode"
+    "required": "Enter the postcode",
+    "notUrl": "Postcode must not be a URL"
   },
   "fullname": {
     "required": "Enter your full name"
@@ -85,7 +92,8 @@
     "date": "Enter a valid date"
   },
   "birth-place-error": {
-    "required": "What is your correct place of birth?"
+    "required": "What is your correct place of birth?",
+    "notUrl": "Place of birth must not be a URL"
   },
   "gender-error": {
     "required": "What is your correct gender?"
@@ -109,7 +117,8 @@
     "required": "Tell us about the problem"
   },
   "national-insurance-error": {
-    "required": "What is your correct National Insurance number?"
+    "required": "What is your correct National Insurance number?",
+    "notUrl": "National Insurance number must not be a URL"
   },
   "photograph-error": {
     "required": "What is wrong with your photograph?"
@@ -122,7 +131,8 @@
     "equal": "Please pick a nationality from the list"
   },
   "sponsor-details-error": {
-    "required": "What are the correct sponsor details?"
+    "required": "What are the correct sponsor details?",
+    "notUrl": "Sponsor reference number must not be a URL"
   },
   "inside-uk": {
     "required": "Tell us where you are"
@@ -141,5 +151,8 @@
   },
   "org-type": {
     "required": "What type of organisation helped you complete this form?"
+  },
+  "phone": {
+    "notUrl": "Phone number must not be a URL"
   }
 }

--- a/apps/correct-mistakes/views/about-error.html
+++ b/apps/correct-mistakes/views/about-error.html
@@ -90,7 +90,7 @@
 
       {{#checkbox}}national-insurance-error-checkbox{{/checkbox}}
       <div id="national-insurance-error-container" class="panel-indent js-hidden {{#errors.national-insurance-error}}validation-error{{/errors.national-insurance-error}}">
-        {{#textarea}}national-insurance-error{{/textarea}}
+        {{#input-text}}national-insurance-error{{/input-text}}
       </div>
 
       {{#checkbox}}damaged-error-checkbox{{/checkbox}}

--- a/apps/lost-stolen/translations/src/en/validation.json
+++ b/apps/lost-stolen/translations/src/en/validation.json
@@ -41,5 +41,8 @@
   },
   "org-type": {
     "required": "Who has helped you fill in this form?"
+  },
+  "phone": {
+    "notUrl": "Phone number must not be a URL"
   }
 }

--- a/apps/not-arrived/fields/address-match.js
+++ b/apps/not-arrived/fields/address-match.js
@@ -23,7 +23,7 @@ module.exports = {
     label: 'fields.delivery-details.label'
   },
   'address-house-number': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-house-number.label',
     dependent: {
       value: 'no',
@@ -31,7 +31,7 @@ module.exports = {
     }
   },
   'address-street': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-street.label',
     dependent: {
       value: 'no',
@@ -39,7 +39,7 @@ module.exports = {
     }
   },
   'address-town': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-town.label',
     dependent: {
       value: 'no',
@@ -47,6 +47,7 @@ module.exports = {
     }
   },
   'address-county': {
+    validate: ['notUrl'],
     label: 'fields.address-county.label',
     dependent: {
       value: 'no',
@@ -54,7 +55,7 @@ module.exports = {
     }
   },
   'address-postcode': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.address-postcode.label',
     dependent: {
       value: 'no',
@@ -62,7 +63,7 @@ module.exports = {
     }
   },
   'case-id': {
-    validate: ['required'],
+    validate: ['required', 'notUrl'],
     label: 'fields.case-id.label',
     hint: 'fields.case-id.hint',
     dependent: {

--- a/apps/not-arrived/translations/src/en/validation.json
+++ b/apps/not-arrived/translations/src/en/validation.json
@@ -41,5 +41,42 @@
     "required": "Enter the date of the letter from the Home Office",
     "before": "The date is in the future",
     "date": "Enter the date in the correct format"
+  },
+  "address-house-number": {
+    "required": "Enter your building name or number",
+    "notUrl": "Building name or number must not be a URL"
+  },
+  "address-street": {
+    "required": "Enter your street",
+    "notUrl": "Street must not be a URL"
+  },
+  "address-town": {
+    "required": "Enter the town or city",
+    "notUrl": "Town or City must not be a URL"
+  },
+  "address-county": {
+    "notUrl": "County must not be a URL"
+  },
+  "address-postcode": {
+    "required": "Enter the postcode",
+    "notUrl": "Postcode must not be a URL"
+  },
+  "contact-address-street": {
+    "required": "Enter your street",
+    "notUrl": "Street must not be a URL"
+  },
+  "contact-address-town": {
+    "required": "Enter the town or city",
+    "notUrl": "Town or City must not be a URL"
+  },
+  "contact-address-county": {
+    "notUrl": "County must not be a URL"
+  },
+  "contact-address-postcode": {
+    "required": "Enter the postcode",
+    "notUrl": "Postcode must not be a URL"
+  },
+  "phone": {
+    "notUrl": "Phone number must not be a URL"
   }
 }

--- a/apps/someone-else/translations/src/en/validation.json
+++ b/apps/someone-else/translations/src/en/validation.json
@@ -65,5 +65,8 @@
   },
   "incapable-details": {
     "required": "Tell us about the problem"
+  },
+  "phone": {
+    "notUrl": "Phone number must not be a URL"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "HomeOffice",
   "dependencies": {
     "express": "^4.17.1",
-    "hof": "^19.13.9",
+    "hof": "^19.13.10",
     "hogan.js": "^3.0.2",
     "hot-shots": "^5.9.0",
     "i18n-future": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "HomeOffice",
   "dependencies": {
     "express": "^4.17.1",
-    "hof": "^19.13.10",
+    "hof": "^19.13.11",
     "hogan.js": "^3.0.2",
     "hot-shots": "^5.9.0",
     "i18n-future": "^2.0.1",

--- a/test/_features/brp/collection_form.feature
+++ b/test/_features/brp/collection_form.feature
@@ -213,3 +213,35 @@ Feature: A user should access the collection problem service and be able to log 
     Then I select 'Continue'
     Then I should see 'Full name must not be a URL' on the page
     And I should see 'Passport Number must not be a URL' on the page
+
+    @validation
+  Scenario: Collection application Contact Details not a URL validation
+    Given I start the 'collection' application journey
+    Then I should be on the 'where' page showing 'From where were you asked to collect your BRP?'
+    Then I check 'collection-where-radio-Sponsor'
+    Then I fill the date 'collection-date' with '30-5-2021'
+    Then I select 'Continue'
+    Then I should be on the 'reasons' page showing 'Why couldn\'t you collect your BRP?'
+    Then I check 'reason-radio-no-brp'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'Ronald Testman'
+    Then I fill the date 'date-of-birth' with '24-5-1990'
+    Then I fill 'nationality' with 'British Overseas Citizen'
+    Then I fill 'passport' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+    Then I check 'use-address'
+    Then I fill 'contact-address-house-number' with 'www.google.com'
+    Then I fill 'contact-address-street' with 'www.google.com'
+    Then I fill 'contact-address-town' with 'www.google.com'
+    Then I fill 'contact-address-county' with 'www.google.com'
+    Then I fill 'contact-address-postcode' with 'www.google.com'
+    Then I fill 'phone' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'Building name or number must not be a URL' on the page
+    Then I should see 'Street must not be a URL' on the page
+    Then I should see 'Town or City must not be a URL' on the page
+    Then I should see 'County must not be a URL' on the page
+    Then I should see 'Postcode must not be a URL' on the page
+    Then I should see 'Phone number must not be a URL' on the page

--- a/test/_features/brp/collection_form.feature
+++ b/test/_features/brp/collection_form.feature
@@ -214,9 +214,12 @@ Feature: A user should access the collection problem service and be able to log 
     Then I should see 'Full name must not be a URL' on the page
     And I should see 'Passport Number must not be a URL' on the page
 
-    @validation
+  @validation
   Scenario: Collection application Contact Details not a URL validation
     Given I start the 'collection' application journey
+    Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?' 
+    Then I check 'previous-submission-no'
+    Then I select 'Continue'
     Then I should be on the 'where' page showing 'From where were you asked to collect your BRP?'
     Then I check 'collection-where-radio-Sponsor'
     Then I fill the date 'collection-date' with '30-5-2021'

--- a/test/_features/brp/correct_mistakes.feature
+++ b/test/_features/brp/correct_mistakes.feature
@@ -203,3 +203,81 @@ Feature: A user should access the correct mistakes service and be able to log an
       Then I select 'Continue'
       Then I should see 'Family name must not be a URL' on the page
       Then I should see 'Given name(s) must not be a URL' on the page
+    
+    @validation
+    Scenario: Correct Mistakes Place of birth and Sponsor reference not a URL validation
+      Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'location' page showing 'Where did you apply for your visa?'
+      Then I check 'location-applied-yes'
+      Then I select 'Continue'
+      Then I should be on the 'about-error' page showing 'What’s the problem with your BRP?'
+      Then I check 'birth-place-error-checkbox'
+      Then I fill 'birth-place-error' with 'wwww.google.com'
+      Then I check 'sponsor-details-error-checkbox'
+      Then I fill 'sponsor-details-error' with 'wwww.google.com'
+      Then I check 'national-insurance-error-checkbox'
+      Then I fill 'national-insurance-error' with 'wwww.google.com'
+      Then I select 'Continue'
+      Then I should see 'Place of birth must not be a URL' on the page
+      Then I should see 'Sponsor reference number must not be a URL' on the page
+      Then I should see 'National Insurance number must not be a URL' on the page
+
+
+     @validation
+     Scenario: Correct Mistakes Contact Details not a URL validation
+      Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'location' page showing 'Where did you apply for your visa?'
+      Then I check 'location-applied-yes'
+      Then I select 'Continue'
+      Then I should be on the 'about-error' page showing 'What’s the problem with your BRP?'
+      Then I check 'last-name-error-checkbox'
+      Then I fill 'last-name-error' with 'Testman'
+      Then I select 'Continue'
+      Then I should be on the 'same-address' page showing 'Is your address the same as the address on the delivery letter?'
+      Then I check 'same-address-radio-yes'
+      Then I select 'Continue'
+      Then I should be on the 'personal-details' page showing 'How do your personal details appear on your BRP?'
+      Then I fill 'fullname' with 'Ronald Testman'
+      Then I fill the date 'date-of-birth' with '30-05-1990'
+      Then I fill 'nationality' with 'Namibia'
+      Then I fill 'brp-card' with 'XR1000123'
+      Then I select 'Continue'
+      Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+      Then I check 'use-address'
+      Then I fill 'contact-address-house-number' with 'www.google.com'
+      Then I fill 'contact-address-street' with 'www.google.com'
+      Then I fill 'contact-address-town' with 'www.google.com'
+      Then I fill 'contact-address-county' with 'www.google.com'
+      Then I fill 'contact-address-postcode' with 'www.google.com'
+      Then I fill 'phone' with 'www.google.com'
+      Then I select 'Continue'
+      Then I should see 'Building name or number must not be a URL' on the page
+      Then I should see 'Street must not be a URL' on the page
+      Then I should see 'Town or City must not be a URL' on the page
+      Then I should see 'County must not be a URL' on the page
+      Then I should see 'Postcode must not be a URL' on the page
+      Then I should see 'Phone number must not be a URL' on the page  
+
+      @validation
+     Scenario: Correct Mistakes Contact Details not a URL validation
+      Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'location' page showing 'Where did you apply for your visa?'
+      Then I check 'location-applied-yes'
+      Then I select 'Continue'
+      Then I should be on the 'about-error' page showing 'What’s the problem with your BRP?'
+      Then I check 'last-name-error-checkbox'
+      Then I fill 'last-name-error' with 'Testman'
+      Then I select 'Continue'
+      Then I should be on the 'same-address' page showing 'Is your address the same as the address on the delivery letter?'
+      Then I check 'same-address-radio-no'
+      Then I fill 'same-address-house-number' with 'www.google.com'
+      Then I fill 'same-address-street' with 'www.google.com'
+      Then I fill 'same-address-town' with 'www.google.com'
+      Then I fill 'same-address-county' with 'www.google.com'
+      Then I fill 'same-address-postcode' with 'www.google.com'
+      Then I select 'Continue'
+      Then I should see 'Building name or number must not be a URL' on the page
+      Then I should see 'Street must not be a URL' on the page
+      Then I should see 'Town or City must not be a URL' on the page
+      Then I should see 'County must not be a URL' on the page
+      Then I should see 'Postcode must not be a URL' on the page

--- a/test/_features/brp/correct_mistakes.feature
+++ b/test/_features/brp/correct_mistakes.feature
@@ -87,7 +87,7 @@ Feature: A user should access the correct mistakes service and be able to log an
     Then I should see the 'What is your correct family name?' error
     Then I should see the 'What are your correct given name(s)?' error
     Then I should see the 'What is your correct place of birth?' error
-    Then I should see the 'Enter a valid date' error
+    Then I should see the 'Enter your date of birth' error
     Then I should see the 'What is your correct gender?' error
     Then I should see the 'What are the correct sponsor details?' error
     Then I should see the 'What is wrong with your signature?' error
@@ -207,6 +207,9 @@ Feature: A user should access the correct mistakes service and be able to log an
     @validation
     Scenario: Correct Mistakes Place of birth and Sponsor reference not a URL validation
       Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?'
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
       Then I should be on the 'location' page showing 'Where did you apply for your visa?'
       Then I check 'location-applied-yes'
       Then I select 'Continue'
@@ -226,6 +229,9 @@ Feature: A user should access the correct mistakes service and be able to log an
      @validation
      Scenario: Correct Mistakes Contact Details not a URL validation
       Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?'
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
       Then I should be on the 'location' page showing 'Where did you apply for your visa?'
       Then I check 'location-applied-yes'
       Then I select 'Continue'
@@ -258,9 +264,12 @@ Feature: A user should access the correct mistakes service and be able to log an
       Then I should see 'Postcode must not be a URL' on the page
       Then I should see 'Phone number must not be a URL' on the page  
 
-      @validation
-     Scenario: Correct Mistakes Contact Details not a URL validation
+     @validation
+     Scenario: Correct Mistakes Same Address not a URL validation
       Given I start the 'correct-mistakes' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?'
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
       Then I should be on the 'location' page showing 'Where did you apply for your visa?'
       Then I check 'location-applied-yes'
       Then I select 'Continue'

--- a/test/_features/brp/lost_stolen.feature
+++ b/test/_features/brp/lost_stolen.feature
@@ -95,6 +95,9 @@ Feature: A user should be able to log a lost or stolen BRP
 @validation
     Scenario: Lost or Stolen application Contact Details not a URL validation
       Given I start the 'lost-stolen' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?'
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
       Then I should be on the 'where' page showing 'Where are you now?'
       Then I check 'inside-uk-yes'
       Then I select 'Continue'

--- a/test/_features/brp/lost_stolen.feature
+++ b/test/_features/brp/lost_stolen.feature
@@ -91,3 +91,34 @@ Feature: A user should be able to log a lost or stolen BRP
       Then I fill 'rep-name' with 'www.google.com'
       Then I submit the application
       Then I should see 'Full name must not be a URL' on the page
+
+@validation
+    Scenario: Lost or Stolen application Contact Details not a URL validation
+      Given I start the 'lost-stolen' application journey
+      Then I should be on the 'where' page showing 'Where are you now?'
+      Then I check 'inside-uk-yes'
+      Then I select 'Continue'
+      Then I should be on the 'date-lost' page showing 'When did you realise you no longer had your BRP?'
+      Then I fill the date 'date-lost' with '30-05-2021'
+      Then I select 'Continue'
+      Then I should be on the 'personal-details' page showing 'What are your personal details?'
+      Then I fill 'fullname' with 'Ronald Testman'
+      Then I fill the date 'date-of-birth' with '30-05-1990'
+      Then I fill 'nationality' with 'Namibia'
+      Then I fill 'brp-card' with 'ZRX000123'
+      Then I select 'Continue'
+      Then I should be on the 'contact-details' page showing 'How should we contact you to tell you what to do next?'
+      Then I check 'use-address'
+      Then I fill 'contact-address-house-number' with 'www.google.com'
+      Then I fill 'contact-address-street' with 'www.google.com'
+      Then I fill 'contact-address-town' with 'www.google.com'
+      Then I fill 'contact-address-county' with 'www.google.com'
+      Then I fill 'contact-address-postcode' with 'www.google.com'
+      Then I fill 'phone' with 'www.google.com'
+      Then I select 'Continue'
+      Then I should see 'Building name or number must not be a URL' on the page
+      Then I should see 'Street must not be a URL' on the page
+      Then I should see 'Town or City must not be a URL' on the page
+      Then I should see 'County must not be a URL' on the page
+      Then I should see 'Postcode must not be a URL' on the page
+      Then I should see 'Phone number must not be a URL' on the page

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -141,10 +141,13 @@ Feature: I should be able to log that my BRP has not arrived
     @validation
     Scenario: Not Arrived application Contact Details not a URL validation
       Given I start the 'not-arrived' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?'
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
       Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
       Then I check 'collection-no'
       Then I select 'Continue'
-      Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
+      Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
       Then I check 'received-yes'
       Then I fill the date 'delivery-date' with '24-5-2020'
       Then I select 'Continue'
@@ -177,10 +180,13 @@ Feature: I should be able to log that my BRP has not arrived
     @validation
     Scenario: Not Arrived application Same Address not a URL validation
       Given I start the 'not-arrived' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?'
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
       Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
       Then I check 'collection-no'
       Then I select 'Continue'
-      Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
+      Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
       Then I check 'received-yes'
       Then I fill the date 'delivery-date' with '24-5-2020'
       Then I select 'Continue'

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -137,3 +137,65 @@ Feature: I should be able to log that my BRP has not arrived
     Then I fill 'email' with 'test@test.test'
     Then I select 'Continue'
     Then I should be on the 'confirm' page showing 'Check the details you have provided'
+
+    @validation
+    Scenario: Not Arrived application Contact Details not a URL validation
+      Given I start the 'not-arrived' application journey
+      Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
+      Then I check 'collection-no'
+      Then I select 'Continue'
+      Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
+      Then I check 'received-yes'
+      Then I fill the date 'delivery-date' with '24-5-2020'
+      Then I select 'Continue'
+      Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
+      Then I check 'address-match-yes'
+      Then I fill 'delivery-details' text area with 'Watch out for the dog!'
+      Then I select 'Continue'
+      Then I should be on the 'personal-details' page showing 'What are your personal details?'
+      Then I fill 'fullname' with 'Ronald Testman'
+      Then I fill the date 'date-of-birth' with '24-5-1990'
+      Then I fill 'nationality' with 'British Overseas Citizen'
+      Then I fill 'passport' with '1234JA2345'
+      Then I select 'Continue'
+      Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+      Then I check 'use-address'
+      Then I fill 'contact-address-house-number' with 'www.google.com'
+      Then I fill 'contact-address-street' with 'www.google.com'
+      Then I fill 'contact-address-town' with 'www.google.com'
+      Then I fill 'contact-address-county' with 'www.google.com'
+      Then I fill 'contact-address-postcode' with 'www.google.com'
+      Then I fill 'phone' with 'www.google.com'
+      Then I select 'Continue'
+      Then I should see 'Building name or number must not be a URL' on the page
+      Then I should see 'Street must not be a URL' on the page
+      Then I should see 'Town or City must not be a URL' on the page
+      Then I should see 'County must not be a URL' on the page
+      Then I should see 'Postcode must not be a URL' on the page
+      Then I should see 'Phone number must not be a URL' on the page
+
+    @validation
+    Scenario: Not Arrived application Same Address not a URL validation
+      Given I start the 'not-arrived' application journey
+      Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
+      Then I check 'collection-no'
+      Then I select 'Continue'
+      Then I should be on the 'letter-received' page showing 'Have you received a letter from the Home Office?'
+      Then I check 'received-yes'
+      Then I fill the date 'delivery-date' with '24-5-2020'
+      Then I select 'Continue'
+      Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
+      Then I check 'address-match-no'
+      Then I fill 'address-house-number' with 'www.google.com'
+      Then I fill 'address-street' with 'www.google.com'
+      Then I fill 'address-town' with 'www.google.com'
+      Then I fill 'address-county' with 'www.google.com'
+      Then I fill 'address-postcode' with 'www.google.com'
+      Then I fill 'case-id' with 'www.google.com'
+      Then I select 'Continue'
+      Then I should see 'Building name or number must not be a URL' on the page
+      Then I should see 'Street must not be a URL' on the page
+      Then I should see 'Town or City must not be a URL' on the page
+      Then I should see 'County must not be a URL' on the page
+      Then I should see 'Postcode must not be a URL' on the page
+      Then I should see 'Case ID number must not be a URL' on the page

--- a/test/_features/brp/someone_else.feature
+++ b/test/_features/brp/someone_else.feature
@@ -160,6 +160,9 @@ Feature: I want someone else to collect my BRP
      @validation
   Scenario: Someone Else Application Contact Details not a URL validation
     Given I start the 'someone-else' application journey
+    Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?' 
+    Then I check 'previous-submission-no'
+    Then I select 'Continue'
     Then I should be on the 'arrange' page showing 'Who would you like to nominate?'
     Then I fill 'someone-else-fullname' with 'Donald Testman'
     Then I fill the date 'someone-else-date' with '24-5-1990'

--- a/test/_features/brp/someone_else.feature
+++ b/test/_features/brp/someone_else.feature
@@ -156,3 +156,39 @@ Feature: I want someone else to collect my BRP
     Then I fill 'rep-name' with 'www.google.com'
     Then I submit the application
     Then I should see 'Full name must not be a URL' on the page
+
+     @validation
+  Scenario: Someone Else Application Contact Details not a URL validation
+    Given I start the 'someone-else' application journey
+    Then I should be on the 'arrange' page showing 'Who would you like to nominate?'
+    Then I fill 'someone-else-fullname' with 'Donald Testman'
+    Then I fill the date 'someone-else-date' with '24-5-1990'
+    Then I fill 'someone-else-nationality' with 'British Overseas Citizen'
+    Then I check 'someone-else-id-type-eu-national-id'
+    Then I fill 'someone-else-id-number' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'reason' page showing 'Why do you need someone else to collect your BRP?'
+    Then I check 'someone-else-reason-radio-incapable'
+    Then I fill 'incapable-details' text area with 'test input'
+    Then I select 'Continue'
+    Then I should be on the 'personal-details' page showing 'What are your personal details?'
+    Then I fill 'fullname' with 'Ronald Testman'
+    Then I fill the date 'date-of-birth' with '24-5-1990'
+    Then I fill 'nationality' with 'British Overseas Citizen'
+    Then I fill 'passport' with '1234JA2345'
+    Then I select 'Continue'
+    Then I should be on the 'contact-details' page showing 'How should we contact you about your BRP?'
+    Then I check 'use-address' 
+    Then I fill 'contact-address-house-number' with 'www.google.com'
+    Then I fill 'contact-address-street' with 'www.google.com'
+    Then I fill 'contact-address-town' with 'www.google.com'
+    Then I fill 'contact-address-county' with 'www.google.com'
+    Then I fill 'contact-address-postcode' with 'www.google.com'
+    Then I fill 'phone' with 'www.google.com'
+    Then I select 'Continue'
+    Then I should see 'Building name or number must not be a URL' on the page
+    Then I should see 'Street must not be a URL' on the page
+    Then I should see 'Town or City must not be a URL' on the page
+    Then I should see 'County must not be a URL' on the page
+    Then I should see 'Postcode must not be a URL' on the page
+    Then I should see 'Phone number must not be a URL' on the page

--- a/yarn.lock
+++ b/yarn.lock
@@ -2794,10 +2794,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^19.13.10:
-  version "19.13.10"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.10.tgz#802c75c982d5cd12f528216cf106c740ce45861b"
-  integrity sha512-mimnsGabkQUaFATKhABs5p8np7c5twX8/rAwcr6fMn+inKOpsQxHoMM+J9ZHcciw8SDBxWiyGdKIx6Joki64Jg==
+hof@^19.13.11:
+  version "19.13.11"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.11.tgz#f116baaccc33067533425a3e216124ed18873eb7"
+  integrity sha512-YQGRU2433cBMzp5Ke++6jqgEROXfwH9d86R+BE17MFB/BNlYlrTrLZrK8HJ6dC6dM76ThlByyLg3mgRLshxntQ==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -3700,9 +3700,9 @@ minimalistic-crypto-utils@^1.0.1:
     brace-expansion "^1.1.7"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixwith@^0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,9 +1099,9 @@ bytes@3.1.0:
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 cached-path-relative@^1.0.0, cached-path-relative@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.2.tgz#a13df4196d26776220cc3356eb147a52dba2c6db"
-  integrity sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.1.0.tgz#865576dfef39c0d6a7defde794d078f5308e3ef3"
+  integrity sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==
 
 caching-transform@^4.0.0:
   version "4.0.0"
@@ -2794,10 +2794,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^19.13.9:
-  version "19.13.9"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.9.tgz#28f1385507ac0b2ade993682a76a7c358c76022d"
-  integrity sha512-lSIenKPI5rE1OgTCAJnnMv4mQPWxCXrxjBV5PrfqwDLkLpjz2zlP83xRg/X5jiU4WaRZf9bJfklNiI4NCaOuSQ==
+hof@^19.13.10:
+  version "19.13.10"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-19.13.10.tgz#802c75c982d5cd12f528216cf106c740ce45861b"
+  integrity sha512-mimnsGabkQUaFATKhABs5p8np7c5twX8/rAwcr6fMn+inKOpsQxHoMM+J9ZHcciw8SDBxWiyGdKIx6Joki64Jg==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"


### PR DESCRIPTION
## What?
- update BRP to latest version of HOF 
- add notUrl validators to relevant text inputs
- add acceptance tests for added notUrl validations
- check that amended input fields still accepted required input 
## Why?
To prevent text input allowing URLs by default
## How?
- Added notUrl validators to fields and added the validation message to be shown.
- Added acceptance tests for added notUrl validations
## Testing?
Tested locally