### PR TITLE
BRP-46 reason displays as blank on /confirm

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -50,4 +50,8 @@ ignore:
     - hof > browserify > module-deps > detective > minimist:
         reason: No update to browserify currently available
         expires: '2022-05-24T16:53:44.487Z'
+  SNYK-JS-ASYNC-2441827:
+    - '*':
+        reason: needs async upgrade to 3.2.2 or higher in hof
+        expires: 2022-06-18T00:00:00.000Z
 patch: {}

--- a/apps/collection/views/confirm.html
+++ b/apps/collection/views/confirm.html
@@ -38,7 +38,7 @@
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.problem-details.where-radio.label{{/t}}</td>
               <td>{{values.collection-where-radio}}{{#values.collection-date}}<br /><span>{{#date}}{{values.collection-date}}{{/date}}</span>{{/values.collection-date}}</td>
-              <td><a href="/collection/where/edit#collection-where-radio-group" class="button">{{#t}}buttons.change.attempted-location{{/t}}</a></td>
+              <td><a href="/collection/where#collection-where-radio-group" class="button">{{#t}}buttons.change.attempted-location{{/t}}</a></td>
             </tr>
 
             <tr>

--- a/apps/collection/views/confirm.html
+++ b/apps/collection/views/confirm.html
@@ -44,37 +44,7 @@
             <tr>
               <td>{{#t}}journeys.collection.pages.check-details.tables.problem-details.reason.label{{/t}}</td>
               <td class="no-white-space">
-                {{#reason.which-post-office}}
-                  {{#t}}fields.reason-radio.options.which-post-office.label{{/t}}
-                {{/reason.which-post-office}}
-
-                {{#reason.under-age}}
-                  {{#t}}fields.reason-radio.options.under-age.label{{/t}}
-                {{/reason.under-age}}
-
-                {{#reason.non-identity}}
-                  {{#t}}fields.reason-radio.options.non-identity.label{{/t}}
-                {{/reason.non-identity}}
-
-                {{#reason.others-identity}}
-                  {{#t}}fields.reason-radio.options.others-identity.label{{/t}}
-                {{/reason.others-identity}}
-
-                {{#reason.passport-family}}
-                  {{#t}}fields.reason-radio.options.passport-family.label{{/t}}
-                {{/reason.passport-family}}
-
-                {{#reason.passport-lost}}
-                  {{#t}}fields.reason-radio.options.passport-lost.label{{/t}}
-                {{/reason.passport-lost}}
-
-                {{#reason.no-brp}}
-                  {{#t}}fields.reason-radio.options.no-brp.label{{/t}}
-                {{/reason.no-brp}}
-
-                {{#reason.other}}
-                  {{#t}}fields.reason-radio.options.other.label{{/t}}
-                {{/reason.other}}
+                {{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}
                 <br />
                 <span>
                   {{#values.which-post-office}}

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,9 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          ({{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}})
+                        {{#reason-radio}}
+                          {{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}
+                        {{/reason-radio}}
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{#reason-radio}}{{#t}}fields.reason-radio.options.non-identity.label{{/t}}{{/reason-radio}}
+                          {{#reason-radio}}{{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}{{/reason-radio}}
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}
+                          ({{#t}}fields.reason-radio.options.[{{values.reason-radio}}].label{{/t}})
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{#reason-radio}}{{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}{{/reason-radio}}
+                          {{#reason-radio}}{{#t}}fields.reason-radio.options.{{reason-radio}}.label{{/t}}{{/reason-radio}}
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,9 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                        {{#reason-radio}}
-                          ({{#t}}fields.reason-radio.options[{{reason-type}}].label{{/t}})
-                        {{/reason-radio}}
+                          {{#reason-radio}}fields.reason-radio.options.non-identity.label{{/reason-radio}}
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,14 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{#which-post-office}}{{#t}}fields.reason-radio.options.which-post-office.label{{/t}}{{/which-post-office}}
-                          {{#under-age}}{{#t}}fields.reason-radio.options.under-age.label{{/t}}{{/under-age}}
-                          {{#non-identity}}{{#t}}fields.reason-radio.options.non-identity.label{{/t}}{{/non-identity}}
-                          {{#others-identity}}{{#t}}fields.reason-radio.options.others-identity.label{{/t}}{{/others-identity}}
-                          {{#passport-family}}{{#t}}fields.reason-radio.options.passport-family.label{{/t}}{{/passport-family}}
-                          {{#passport-lost}}{{#t}}fields.reason-radio.options.passport-lost.label{{/t}}{{/passport-lost}}
-                          {{#no-brp}}{{#t}}fields.reason-radio.options.no-brp.label{{/t}}{{/no-brp}}
-                          {{#other}}{{#t}}fields.reason-radio.options.other.label{{/t}}{{/other}}
+                          {{#t}}fields.reason-radio.options[{{values}}].label{{/t}}
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -72,7 +72,7 @@
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                         {{#reason-radio}}
-                          {{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}
+                          {{#t}}fields.reason-radio.options.label{{/t}}
                         {{/reason-radio}}
                         </p>
                       </td>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -72,7 +72,7 @@
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                         {{#reason-radio}}
-                          {{#t}}fields.reason-radio.options.label{{/t}}
+                          ({{#t}}fields.reason-radio.options[{{reason-type}}].label{{/t}})
                         {{/reason-radio}}
                         </p>
                       </td>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          ({{#t}}fields.reason-radio.options.[{{values.reason-radio}}].label{{/t}})
+                          ({{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}})
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{#t}}fields.reason-radio.options[{{values}}].label{{/t}}
+                          {{#t}}fields.reason-radio.options.{{values.reason-radio}}.label{{/t}}
                         </p>
                       </td>
                     </tr>

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -71,7 +71,7 @@
                     <tr style="border-top: 1px solid #009390;">
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{#reason-radio}}fields.reason-radio.options.non-identity.label{{/reason-radio}}
+                          {{#reason-radio}}{{#t}}fields.reason-radio.options.non-identity.label{{/t}}{{/reason-radio}}
                         </p>
                       </td>
                     </tr>


### PR DESCRIPTION
What 
Changed confirm view to use the value of the reason radio as the label and changed email template so the value of the reason radio is sent to recipient

Why 
on /reasons the user selects a radio button which opens an optional text input. If the user selects a radio button but does not input anything in the optional text input, reasons on the /confirm page will be blank.

Testing 
Tested locally and on branch

Anything else?
Snyk vulnerability SNYK-JS-ASYNC-2441827 added to synk ignore file and has been raised as a ticket