### PR TITLE
Move post option to the end of the page on all journeys

### DIFF
--- a/apps/collection/views/contact-details.html
+++ b/apps/collection/views/contact-details.html
@@ -33,6 +33,8 @@
 
       {{#input-text}}email{{/input-text}}
 
+      {{#input-phone}}phone{{/input-phone}}
+
       {{#checkbox}}use-address{{/checkbox}}
 
       <fieldset id="address-group" class="panel-indent js-hidden">
@@ -64,8 +66,6 @@
         </div>
 
       </fieldset>
-
-      {{#input-phone}}phone{{/input-phone}}
 
       {{#input-submit}}continue{{/input-submit}}
 

--- a/apps/correct-mistakes/views/contact-details.html
+++ b/apps/correct-mistakes/views/contact-details.html
@@ -33,6 +33,8 @@
 
       {{#input-text}}email{{/input-text}}
 
+      {{#input-phone}}phone{{/input-phone}}
+
       {{#checkbox}}use-address{{/checkbox}}
 
       <fieldset id="address-group" class="panel-indent js-hidden">
@@ -64,8 +66,6 @@
         </div>
 
       </fieldset>
-
-      {{#input-phone}}phone{{/input-phone}}
 
       {{#input-submit}}continue{{/input-submit}}
 

--- a/apps/lost-stolen/views/contact-details.html
+++ b/apps/lost-stolen/views/contact-details.html
@@ -33,6 +33,8 @@
 
         {{#input-text}}email{{/input-text}}
 
+        {{#input-phone}}phone{{/input-phone}}
+
         {{#location.inside-uk}}
           {{#checkbox}}use-address{{/checkbox}}
 
@@ -66,8 +68,6 @@
 
           </fieldset>
         {{/location.inside-uk}}
-
-        {{#input-phone}}phone{{/input-phone}}
 
         {{#input-submit}}continue{{/input-submit}}
 

--- a/apps/not-arrived/views/contact-details.html
+++ b/apps/not-arrived/views/contact-details.html
@@ -33,6 +33,8 @@
 
         {{#input-text}}email{{/input-text}}
 
+        {{#input-phone}}phone{{/input-phone}}
+
         {{#checkbox}}use-address{{/checkbox}}
 
         <fieldset id="address-group" class="panel-indent js-hidden">
@@ -64,8 +66,6 @@
           </div>
 
         </fieldset>
-
-        {{#input-phone}}phone{{/input-phone}}
 
         {{#input-submit}}continue{{/input-submit}}
 

--- a/apps/someone-else/views/contact-details.html
+++ b/apps/someone-else/views/contact-details.html
@@ -33,6 +33,8 @@
 
       {{#input-text}}email{{/input-text}}
 
+      {{#input-phone}}phone{{/input-phone}}
+
       {{#checkbox}}use-address{{/checkbox}}
 
       <fieldset id="address-group" class="panel-indent js-hidden">
@@ -64,8 +66,6 @@
         </div>
 
       </fieldset>
-
-      {{#input-phone}}phone{{/input-phone}}
 
       {{#input-submit}}continue{{/input-submit}}
 


### PR DESCRIPTION
**### What?**
Email option to be more prominent.  Moving _post_ option to the end to deter users from selecting the post option.  

**### Why?**
To drive customers to choosing to correspond by email, as by post slows down responses and is far more resource intensive.

**### How?**
Moving the phone input field above the _post_ option on all journeys.

**### Testing?**