### PR TITLE
BRP-26-add after validator to date lost field and acceptance test

### DIFF
--- a/apps/lost-stolen/fields/date-lost.js
+++ b/apps/lost-stolen/fields/date-lost.js
@@ -4,7 +4,7 @@ const date = require('hof').components.date;
 
 module.exports = {
   'date-lost': date('date-lost', {
-    validate: ['required', 'before'],
+    validate: ['required', 'before', { type: 'after', arguments: ['20150730']}],
     legend: 'fields.date-lost.legend',
     hint: 'fields.date-lost.hint'
   })

--- a/apps/lost-stolen/translations/src/en/fields.json
+++ b/apps/lost-stolen/translations/src/en/fields.json
@@ -47,7 +47,7 @@
     }
   },
   "date-lost": {
-    "hint": "For example: 11 6 2015"
+    "hint": "For example: 11 8 2015"
   },
   "date-lost-day": {
     "label": "Day"

--- a/apps/lost-stolen/translations/src/en/validation.json
+++ b/apps/lost-stolen/translations/src/en/validation.json
@@ -26,7 +26,8 @@
   "date-lost": {
     "required": "When did you lose or have your BRP stolen?",
     "before": "The date is in the future",
-    "date": "Enter a valid date"
+    "date": "Enter a valid date",
+    "after": "Enter a date from 31/07/2015"
   },
   "brp-card": {
     "required": "What is your BRP number?",

--- a/test/_features/brp/lost_stolen.feature
+++ b/test/_features/brp/lost_stolen.feature
@@ -91,3 +91,17 @@ Feature: A user should be able to log a lost or stolen BRP
       Then I fill 'rep-name' with 'www.google.com'
       Then I submit the application
       Then I should see 'Full name must not be a URL' on the page
+    
+  @validation_error
+    Scenario: Lost or stolen application - Preventing user from entering a date before 31st July 2015
+      Given I start the 'lost-stolen' application journey
+      Then I should be on the 'previous-submission' page showing 'Have you previously submitted this request?' 
+      Then I check 'previous-submission-no'
+      Then I select 'Continue'
+      Then I should be on the 'where' page showing 'Where are you now?'
+      Then I check 'inside-uk-yes'
+      Then I select 'Continue'
+      Then I should be on the 'date-lost' page showing 'When did you realise you no longer had your BRP?'
+      Then I fill the date 'date-lost' with '30-07-2015'
+      Then I select 'Continue'
+      Then I should see the 'Enter a date from 31/07/2015' error


### PR DESCRIPTION
What
Added after validator to date lost field in lost-stolen journey to stop user from entering a date before the launch of Biometric Residence Permits.

Why
Users were able to enter a date into the lost field before the launch of biometric residence permits

Testing
Added acceptance test and tested locally 