### PR TITLE
BRP-71 - Added max property and used in truncate template

### DIFF
--- a/apps/correct-mistakes/behaviours/about-error.js
+++ b/apps/correct-mistakes/behaviours/about-error.js
@@ -34,7 +34,7 @@ function getTruncatedItems(req) {
 
   truncateConfigs.forEach(config => {
     if (isTooLong.call(this, config.id, config.max, req)) {
-      items.unshift({id: config.id});
+      items.unshift({id: config.id, max: config.max});
     }
   });
   return items;

--- a/apps/correct-mistakes/behaviours/truncated.js
+++ b/apps/correct-mistakes/behaviours/truncated.js
@@ -20,7 +20,8 @@ function truncatedItem(req) {
       pretty: prettyName(itemOne.id),
       value: req.form.values[itemOne.id],
       length: req.form.values[itemOne.id].length,
-      slice: req.form.values[itemOne.id].slice(0, 30)
+      slice: req.form.values[itemOne.id].slice(0, itemOne.max),
+      max: itemOne.max
     };
   }
 }

--- a/apps/correct-mistakes/translations/src/en/pages.json
+++ b/apps/correct-mistakes/translations/src/en/pages.json
@@ -109,7 +109,8 @@
         "parts": {
           "one": "Your",
           "two": "has",
-          "three": "letters. Your BRP can only show a maximum of 30 letters, so it is shortened to this on your BRP:"
+          "three": "letters. Your BRP can only show a maximum of ",
+          "four": " letters, so it is shortened to this on your BRP:"
         }
       },
       "three": {

--- a/apps/correct-mistakes/views/truncated.html
+++ b/apps/correct-mistakes/views/truncated.html
@@ -26,7 +26,7 @@
 
     <p><strong>{{truncatedItem.value}}</strong></p>
 
-    <p>{{#t}}pages.truncated.paras.two.parts.one{{/t}} {{truncatedItem.pretty}} {{#t}}pages.truncated.paras.two.parts.two{{/t}} {{truncatedItem.length}} {{#t}}pages.truncated.paras.two.parts.three{{/t}}</p>
+    <p>{{#t}}pages.truncated.paras.two.parts.one{{/t}} {{truncatedItem.pretty}} {{#t}}pages.truncated.paras.two.parts.two{{/t}} {{truncatedItem.length}} {{#t}}pages.truncated.paras.two.parts.three{{/t}}{{truncatedItem.max}}{{#t}}pages.truncated.paras.two.parts.four{{/t}}</p>
 
     <p><strong>{{truncatedItem.slice}}</strong></p>
 


### PR DESCRIPTION
What?
The place of birth is currently hard-coded to use the same truncation template text as other text fields so this has been expanded to pass the desired length through to the template which is then consumed in the template

Why?
The template had no idea of the desired length prior to this fix so we had no way to display the correct error message 

How?
Added a new max property to the session and consumed within the truncate template

Testing?
Tested locally

Screenshots (optional)
Anything Else?