### PR TITLE
Added max property and used in truncate template

### DIFF
--- a/apps/correct-mistakes/behaviours/about-error.js
+++ b/apps/correct-mistakes/behaviours/about-error.js
@@ -34,7 +34,7 @@ function getTruncatedItems(req) {
 
   truncateConfigs.forEach(config => {
     if (isTooLong.call(this, config.id, config.max, req)) {
-      items.unshift({id: config.id});
+      items.unshift({id: config.id, max: config.max});
     }
   });
   return items;

--- a/apps/correct-mistakes/behaviours/truncated.js
+++ b/apps/correct-mistakes/behaviours/truncated.js
@@ -20,7 +20,8 @@ function truncatedItem(req) {
       pretty: prettyName(itemOne.id),
       value: req.form.values[itemOne.id],
       length: req.form.values[itemOne.id].length,
-      slice: req.form.values[itemOne.id].slice(0, 30)
+      slice: req.form.values[itemOne.id].slice(0, itemOne.max),
+      max: itemOne.max
     };
   }
 }

--- a/apps/correct-mistakes/translations/src/en/pages.json
+++ b/apps/correct-mistakes/translations/src/en/pages.json
@@ -109,7 +109,8 @@
         "parts": {
           "one": "Your",
           "two": "has",
-          "three": "letters. Your BRP can only show a maximum of 30 letters, so it is shortened to this on your BRP:"
+          "three": "letters. Your BRP can only show a maximum of ",
+          "four": " letters, so it is shortened to this on your BRP:"
         }
       },
       "three": {

--- a/apps/correct-mistakes/views/truncated.html
+++ b/apps/correct-mistakes/views/truncated.html
@@ -26,7 +26,7 @@
 
     <p><strong>{{truncatedItem.value}}</strong></p>
 
-    <p>{{#t}}pages.truncated.paras.two.parts.one{{/t}} {{truncatedItem.pretty}} {{#t}}pages.truncated.paras.two.parts.two{{/t}} {{truncatedItem.length}} {{#t}}pages.truncated.paras.two.parts.three{{/t}}</p>
+    <p>{{#t}}pages.truncated.paras.two.parts.one{{/t}} {{truncatedItem.pretty}} {{#t}}pages.truncated.paras.two.parts.two{{/t}} {{truncatedItem.length}} {{#t}}pages.truncated.paras.two.parts.three{{/t}}{{truncatedItem.max}}{{#t}}pages.truncated.paras.two.parts.four{{/t}}</p>
 
     <p><strong>{{truncatedItem.slice}}</strong></p>
 


### PR DESCRIPTION
What?
There is a bug in the birth-place truncation logic whereby the max 16 characters is ignored and instead it always shows as if the max length is 30 characters. We have fixed this by introducing a new property called "max" which we pass all the way down to the template, and we have adjusted the template to show the new field.

Why?
Without this we would have been unable to display the correct error message

How?
Added a new max property to the session, added an extra paragraph in the error message object and adjusted the template accordingly.

Testing?
Tested locally

Screenshots (optional)
Anything Else?