### PR TITLE
BRP-25: Fix Date format inconsistent across other forms

### DIFF
--- a/apps/lost-stolen/views/confirm.html
+++ b/apps/lost-stolen/views/confirm.html
@@ -35,7 +35,7 @@
         <table id="personal-details" class="table-details">
           <tr data-id="date-lost">
             <td>{{#t}}pages.check-details.table.headers.date-lost{{/t}}</td>
-            <td>{{values.date-lost}}</td>
+            <td>{{#date}}{{values.date-lost}}{{/date}}</td>
             <td><a href="date-lost/edit#date-lost-day" id='date-lost-change' class="button">{{#t}}buttons.change.date-lost{{/t}}</a></td>
           </tr>
           <tr data-id="fullname">
@@ -45,7 +45,7 @@
           </tr>
           <tr data-id="date-of-birth">
             <td>{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</td>
-            <td>{{values.date-of-birth}}</td>
+            <td>{{#date}}{{values.date-of-birth}}{{/date}}</td>
             <td><a href="personal-details/edit#date-of-birth-day" id='date-of-birth-change' class="button">{{#t}}buttons.change.date-of-birth{{/t}}</a></td>
           </tr>
           <tr data-id="nationality">


### PR DESCRIPTION
What?

BRP- Date format inconsistent across other forms.

collection' journey Date format is different from 'lost stolen' journey form.

How?
Added {{#date}} into confirm.html to display to display the same date.

Testing?
Running lint, unit and acceptance tests locally.

Screenshots?

<img width="735" alt="image" src="https://user-images.githubusercontent.com/13870434/170062925-c325b060-2e01-4039-b68a-97602d74ebb1.png">
