### PR TITLE
BRP-67: Make Fullname mandatory

### DIFF
--- a/apps/lost-stolen/fields/personal-details.js
+++ b/apps/lost-stolen/fields/personal-details.js
@@ -11,7 +11,7 @@ const beforeTodayValidator = {
 
 module.exports = {
   fullname: {
-    validate: 'notUrl'
+    validate: ['required','notUrl'],
   },
   'brp-card': {
     validate: [{type: 'regex', arguments: /(^[a-z][a-z](\d|X)\d{6}$)|(^$)/gi }],

--- a/apps/lost-stolen/fields/personal-details.js
+++ b/apps/lost-stolen/fields/personal-details.js
@@ -11,7 +11,7 @@ const beforeTodayValidator = {
 
 module.exports = {
   fullname: {
-    validate: ['required','notUrl'],
+    validate: ['required', 'notUrl']
   },
   'brp-card': {
     validate: [{type: 'regex', arguments: /(^[a-z][a-z](\d|X)\d{6}$)|(^$)/gi }],


### PR DESCRIPTION
What?

BRP-Lost-stolen-Full name is optional field however in all other BRP routes its mandatory field.

How?

Updated fullname validator to be required

```
 fullname: {
    validate: ['required', 'notUrl']
  },
 ```

Testing?
Running `npm run test`

Screenshots?
<img width="648" alt="image" src="https://user-images.githubusercontent.com/13870434/170068504-2f35cfef-ad4c-4d82-bbc0-d49518faa624.png">

<img width="660" alt="image" src="https://user-images.githubusercontent.com/13870434/170068583-a78e1d6d-4782-471e-9a51-3b37f5797468.png">
