### PR TITLE
BRP-95: Add case ID to not-arrived letter-received route and reformat caseworker emails

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -193,6 +193,7 @@ steps:
   - name: acceptance_tests_branch
     <<: *acceptance_tests
     commands:
+      - export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
       - export ACCEPTANCE_HOST_NAME=https://$${APP_NAME}-$${DRONE_SOURCE_BRANCH}.internal.$${BRANCH_ENV}.homeoffice.gov.uk
       - export CUCUMBER_PUBLISH_ENABLED=true
       - npx playwright install

--- a/apps/collection/fields/index.js
+++ b/apps/collection/fields/index.js
@@ -88,5 +88,19 @@ module.exports = {
   },
   passport: {
     validate: ['required', 'notUrl']
+  },
+  email: {
+    validate: ['email'],
+    type: 'email'
+  },
+  phone: {
+    label: 'fields.phone.label'
+  },
+  'contact-address-county': {
+    label: 'fields.address-county.label',
+    dependent: {
+      value: 'true',
+      field: 'use-address'
+    }
   }
 };

--- a/apps/collection/translations/src/en/journeys.json
+++ b/apps/collection/translations/src/en/journeys.json
@@ -15,6 +15,12 @@
             "where-radio": {
               "label": "Attempted collection"
             },
+            "attempted-collection-date": {
+              "label": "Date"
+            },
+            "describe-problem": {
+              "label": "Describe the problem"
+            },
             "reason": {
               "label": "Reason",
               "under-age": "Under age"

--- a/apps/collection/translations/src/en/pages.json
+++ b/apps/collection/translations/src/en/pages.json
@@ -28,6 +28,7 @@
     "table": {
       "headers": {
         "date-lost": "Date lost",
+        "case-id-number": "Case ID Number",
         "contact-address": "Contact address",
         "address": "New address",
         "delivery-address": "Delivery address",

--- a/apps/correct-mistakes/fields/uk-address.js
+++ b/apps/correct-mistakes/fields/uk-address.js
@@ -54,5 +54,19 @@ module.exports = {
       value: 'yes',
       field: 'uk-address-radio'
     }
+  },
+  email: {
+    validate: ['required', 'email'],
+    type: 'email'
+  },
+  phone: {
+    label: 'fields.phone.label'
+  },
+  'contact-address-county': {
+    label: 'fields.address-county.label',
+    dependent: {
+      value: 'true',
+      field: 'use-address'
+    }
   }
 };

--- a/apps/lost-stolen/fields/personal-details.js
+++ b/apps/lost-stolen/fields/personal-details.js
@@ -22,5 +22,19 @@ module.exports = {
     validate: ['required', beforeTodayValidator],
     legend: 'fields.date-of-birth.legend',
     hint: 'fields.date-of-birth.hint'
-  })
+  }),
+  email: {
+    validate: ['required', 'email'],
+    type: 'email'
+  },
+  phone: {
+    label: 'fields.phone.label'
+  },
+  'contact-address-county': {
+    label: 'fields.address-county.label',
+    dependent: {
+      value: 'true',
+      field: 'use-address'
+    }
+  }
 };

--- a/apps/not-arrived/fields/address-match.js
+++ b/apps/not-arrived/fields/address-match.js
@@ -69,5 +69,19 @@ module.exports = {
       value: 'no',
       field: 'address-match'
     }
+  },
+  email: {
+    validate: ['required', 'email'],
+    type: 'email'
+  },
+  phone: {
+    label: 'fields.phone.label'
+  },
+  'contact-address-county': {
+    label: 'fields.address-county.label',
+    dependent: {
+      value: 'true',
+      field: 'use-address'
+    }
   }
 };

--- a/apps/not-arrived/fields/letter-received.js
+++ b/apps/not-arrived/fields/letter-received.js
@@ -46,8 +46,14 @@ module.exports = {
   'no-letter': {
     className: 'form-checkbox',
     dependent: {
-      value: 'yes',
-      field: 'received'
+      field: 'received',
+      value: 'yes'
+    }
+  },
+  'case-id-number': {
+    dependent: {
+      field: 'received',
+      value: 'yes'
     }
   }
 };

--- a/apps/not-arrived/index.js
+++ b/apps/not-arrived/index.js
@@ -26,7 +26,8 @@ module.exports = {
       fields: [
         'received',
         'delivery-date',
-        'no-letter'
+        'no-letter',
+        'case-id-number'
       ],
       backLink: 'consignment-number',
       next: '/same-address',

--- a/apps/not-arrived/translations/src/en/buttons.json
+++ b/apps/not-arrived/translations/src/en/buttons.json
@@ -1,6 +1,7 @@
 {
   "change": {
     "delivery-date": "Change <span class=\"visuallyhidden\">date on letter</span>",
+    "case-id-number": "Change <span class=\"visuallyhidden\">case id number</span>",
     "no-letter": "Change <span class=\"visuallyhidden\">no letter</span>",
     "delivery-details": "Change <span class=\"visuallyhidden\">delivery details</span>",
     "new-address": "Change <span class=\"visuallyhidden\">delivery address</span>",

--- a/apps/not-arrived/translations/src/en/fields.json
+++ b/apps/not-arrived/translations/src/en/fields.json
@@ -47,6 +47,10 @@
       }
     }
   },
+  "case-id-number": {
+    "label": "Case ID Number",
+    "hint": "(Enter the case ID found on your visa decision letter.)"
+  },
   "no-letter": {
     "label": "I don't have the letter anymore"
   },

--- a/apps/not-arrived/translations/src/en/pages.json
+++ b/apps/not-arrived/translations/src/en/pages.json
@@ -84,6 +84,7 @@
         "email": "Email address",
         "phone": "Phone number",
         "delivery-date": "Date of letter",
+        "case-id-number": "Case ID Number",
         "no-letter": "You do not have the delivery letter",
         "delivery-details": "Delivery details",
         "delivery-address": "Delivery address",

--- a/apps/not-arrived/views/confirm.html
+++ b/apps/not-arrived/views/confirm.html
@@ -50,6 +50,14 @@
             </tr>
             {{/values.no-letter}}
 
+            {{#values.case-id-number}}
+            <tr>
+              <td>{{#t}}pages.check-details.table.headers.case-id-number{{/t}}</td>
+              <td>{{values.case-id-number}}</td>
+              <td><a href="letter-received/edit#case-id-number" class="button">{{#t}}buttons.change.case-id-number{{/t}}</a></td>
+            </tr>
+            {{/values.case-id-number}}
+
             {{^values.address-street}}
             {{#values.delivery-details}}
             <tr>

--- a/apps/not-arrived/views/letter-received.html
+++ b/apps/not-arrived/views/letter-received.html
@@ -62,6 +62,8 @@
           </div>
 
           {{#checkbox}}no-letter{{/checkbox}}
+          {{#renderField}}case-id-number{{/renderField}}
+
         </fieldset>
 
         {{#input-submit}}continue{{/input-submit}}

--- a/apps/someone-else/fields/reason.js
+++ b/apps/someone-else/fields/reason.js
@@ -21,5 +21,19 @@ module.exports = {
       },
       'under-age'
     ]
+  },
+  email: {
+    validate: ['required', 'email'],
+    type: 'email'
+  },
+  phone: {
+    label: 'fields.phone.label'
+  },
+  'contact-address-county': {
+    label: 'fields.address-county.label',
+    dependent: {
+      value: 'true',
+      field: 'use-address'
+    }
   }
 };

--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -61,14 +61,16 @@
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.problem-details.where-radio.label{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.problem-details.where-radio.label{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{collection-where-radio}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td colspan="2"width="100%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#collection-date}}{{collection-date}}{{/collection-date}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.problem-details.attempted-collection-date.label{{/t}}: </p></td>
+                      <td colspan="2"width="100%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#collection-date}}{{collection-date}}{{/collection-date}}{{^collection-date}}None Given{{/collection-date}}</p></td>
                     </tr>
-                    {{#t}}journeys.collection.pages.check-details.tables.problem-details.reason.label{{/t}}
+
                     <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.problem-details.reason.label{{/t}}: </p></td>
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                           {{#reason-radio}}{{#t}}fields.reason-radio.options.{{reason-radio}}.label{{/t}}{{/reason-radio}}
@@ -76,96 +78,103 @@
                       </td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
+                     <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.problem-details.describe-problem.label{{/t}}: </p></td>
                       <td colspan="2" width="100%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                           {{#which-post-office}}{{which-post-office}}{{/which-post-office}}
-                          {{#under-age}}{{under-age}}{{/under-age}}
-                          {{#non-identity}}{{non-identity}}{{/non-identity}}
-                          {{#others-identity}}{{others-identity}}{{/others-identity}}
-                          {{#passport-family}}{{passport-family}}{{/passport-family}}
-                          {{#passport-lost}}{{passport-lost}}{{/passport-lost}}
-                          {{#other}}{{other}}{{/other}}
+                          {{^which-post-office}}
+                            {{#under-age}}{{under-age}}{{/under-age}}
+                            {{^under-age}}
+                              {{#non-identity}}{{non-identity}}{{/non-identity}}
+                              {{^non-identity}}
+                                {{#others-identity}}{{others-identity}}{{/others-identity}}
+                                {{^others-identity}}
+                                  {{#passport-family}}{{passport-family}}{{/passport-family}}
+                                  {{^passport-family}}
+                                    {{#passport-lost}}{{passport-lost}}{{/passport-lost}}
+                                    {{^passport-lost}}
+                                      {{#other}}{{other}}{{/other}}
+                                      {{^other}}None Given{{/other}}
+                                    {{/passport-lost}}
+                                  {{/passport-family}}
+                                {{/others-identity}}
+                              {{/non-identity}}
+                            {{/under-age}}
+                          {{/which-post-office}}
                         </p>
                       </td>
                     </tr>
                   </table>
 
-                  {{#nominated-fullname}}
-                    <!-- OTHER PERSONS DETAILS TABLE -->
-                    <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.title{{/t}}</p>
+                  <!-- OTHER PERSONS DETAILS TABLE -->
+                  <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.title{{/t}}: </p>
 
-                    <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.fullname{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nominated-fullname}}</p></td>
-                      </tr>
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.date-of-birth{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nominated-date}}</p></td>
-                      </tr>
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.nationality{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nominated-nationality}}</p></td>
-                      </tr>
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.id-number{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nominated-id-number}}</p></td>
-                      </tr>
-                    </table>
-                  {{/nominated-fullname}}
+                  <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.fullname{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#nominated-fullname}}{{nominated-fullname}}{{/nominated-fullname}}{{^nominated-fullname}}None Given{{/nominated-fullname}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.date-of-birth{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#nominated-date}}{{nominated-date}}{{/nominated-date}}{{^nominated-date}}None Given{{/nominated-date}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.nationality{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#nominated-nationality}}{{nominated-nationality}}{{/nominated-nationality}}{{^nominated-nationality}}None Given{{/nominated-nationality}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.others-details.id-number{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#nominated-id-number}}{{nominated-id-number}}{{/nominated-id-number}}{{^nominated-id-number}}None Given{{/nominated-id-number}}</p></td>
+                    </tr>
+                  </table>
 
                   <!-- PERSONAL DETAILS TABLE -->
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">{{#t}}journeys.collection.pages.check-details.tables.personal-details.title{{/t}}</p>
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}</p></td>
-                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{fullname}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#fullname}}{{fullname}}{{/fullname}}{{^fullname}}None Given{{/fullname}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</p></td>
-                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#date-of-birth}}{{date-of-birth}}{{/date-of-birth}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#date-of-birth}}{{date-of-birth}}{{/date-of-birth}}{{^date-of-birth}}None Given{{/date-of-birth}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}</p></td>
-                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nationality}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#nationality}}{{nationality}}{{/nationality}}{{^nationality}}None Given{{/nationality}}</p></td>
                     </tr>
-                    {{#passport}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{passport}}</p></td>
-                      </tr>
-                    {{/passport}}
-                    {{#email}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.email{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{email}}</p></td>
-                      </tr>
-                    {{/email}}
-                    {{#phone}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.phone{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{phone}}</p></td>
-                      </tr>
-                    {{/phone}}
-                    {{^email}}
-                    {{#contact-address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}</p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#passport}}{{passport}}{{/passport}}{{^passport}}None Given{{/passport}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.email{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#email}}{{email}}{{/email}}{{^email}}None Given{{/email}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.phone{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#phone}}{{phone}}{{/phone}}{{^phone}}None Givem{{/phone}}</p></td>
+                    </tr>
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}: </p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#contact-address-street}}
                             {{contact-address-house-number}} {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/contact-address-street}}
-                    {{/email}}
+                          {{/contact-address-street}}
+                          {{^contact-address-street}}None Given{{/contact-address-street}}
+                        </p>
+                      </td>
+                    </tr>
+
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
@@ -175,7 +184,6 @@
                       </tr>
                     {{/org-type}}
                   </table>
-
                 {{/data}}
               </td>
               <td width="25%">&nbsp;</td>
@@ -184,6 +192,5 @@
         </td>
       </tr>
     </table>
-
   </body>
 </html>

--- a/services/email/templates/caseworker/html/delivery.mus
+++ b/services/email/templates/caseworker/html/delivery.mus
@@ -7,7 +7,7 @@
 <!--[if !IE]><!--> <html>             <!--<![endif]-->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-  <meta content="utf-8" http-equiv="encoding">
+    <meta content="utf-8" http-equiv="encoding">
     <!-- Use title if it's in the page YAML frontmatter -->
     <title>{{subject}}</title>
 </head>
@@ -60,46 +60,43 @@
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{fullname}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{date-of-birth}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.nationality{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.nationality{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nationality}}</p></td>
                     </tr>
-                    {{#passport}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{passport}}</p></td>
-                      </tr>
-                    {{/passport}}
-                    {{#consignment-number}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.consignment-number{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{consignment-number}}</p></td>
-                      </tr>
-                    {{/consignment-number}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#passport}}{{passport}}{{/passport}}{{^passport}}None Given{{/passport}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.consignment-number{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#consignment-number}}{{consignment-number}}{{/consignment-number}}{{^consignment-number}}None Given{{/consignment-number}}</p></td>
+                    </tr>
 
-                    {{#address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}</p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}: </p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#address-street}}
                             {{address-house-number}} {{address-street}},
                             {{address-town}},
                             {{#address-county}}{{address-county}},{{/address-county}}
                             {{address-postcode}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/address-street}}
+                          {{/address-street}}
+                          {{^address-street}}None Given{{/address-street}}
+                        </p>
+                      </td>
+                    </tr>
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
@@ -113,84 +110,83 @@
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Contact Details</p>
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                    {{#contact-address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}</p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}: </p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#contact-address-street}}
                             {{contact-address-house-number}} {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/contact-address-street}}
-                    {{#phone}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.phone{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{phone}}</p></td>
-                      </tr>
-                    {{/phone}}
-                    {{#email}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.email.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{email}}</p></td>
-                      </tr>
-                    {{/email}}
+                          {{/contact-address-street}}
+                          {{^contact-address-street}}None Given{{/contact-address-street}}
+                        </p>
+                      </td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.phone{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#phone}}{{phone}}{{/phone}}{{^phone}}None Given{{/phone}}</p></td>
+                    </tr>
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.email.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#email}}{{email}}{{/email}}{{^email}}None Given{{/email}}</p></td>
+                    </tr>
                   </table>
 
                    <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Delivery Details</p>
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                    {{#delivery-date}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.delivery-date{{/t}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.delivery-date{{/t}}: </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{delivery-date}}
+                            {{#delivery-date}}{{delivery-date}}{{/delivery-date}}{{^delivery-date}}None Given{{/delivery-date}}
                           </p>
                         </td>
                       </tr>
-                    {{/delivery-date}}
-
-                    {{^address-street}}
-                      {{#delivery-details}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.delivery-details{{/t}}</p>
-                        </td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">{{delivery-details}}
-                          </p>
-                        </td>
-                      </tr>
-                      {{/delivery-details}}
-                      {{/address-street}}
-
-                      {{#address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.delivery-address{{/t}}
-                          </p>
-                        </td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.case-id-number{{/t}}: </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{address-house-number}} {{address-street}},
-                          {{address-town}},
-                          {{#address-county}}{{address-county}},{{/address-county}}
-                          {{address-postcode}}
+                            {{#case-id-number}}{{case-id-number}}{{/case-id-number}}{{^case-id-number}}None Given{{/case-id-number}}
                           </p>
                         </td>
                       </tr>
+
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.case-id.label{{/t}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.delivery-details{{/t}}: </p>
+                        </td>
                         <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">{{case-id}}</p>
+                          <p style="font-size: 16px; color: #000; margin: 10px 0;">{{#delivery-details}}{{delivery-details}}{{/delivery-details}}{{^delivery-details}}None Given{{/delivery-details}}
+                          </p>
                         </td>
                       </tr>
-                    {{/address-street}}
 
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.delivery-address{{/t}}: </p>
+                          </td>
+                          <td width="75%">
+                            <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                            {{#address-street}}
+                              {{address-house-number}} {{address-street}},
+                              {{address-town}},
+                              {{#address-county}}{{address-county}},{{/address-county}}
+                              {{address-postcode}}
+                            {{/address-street}}
+                            {{^address-street}}
+                              None Given
+                            {{/address-street}}
+                            </p>
+                          </td>
+                      </tr>
+                      <tr style="border-top: 1px solid #009390;">
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.case-id.label{{/t}}: </p></td>
+                        <td width="75%">
+                          <p style="font-size: 16px; color: #000; margin: 10px 0;">{{#case-id}}{{case-id}}{{/case-id}}{{^case-id}}None Given{{/case-id}}</p>
+                        </td>
+                      </tr>
                   </table>
-
                 {{/data}}
               </td>
               <td width="25%">&nbsp;</td>
@@ -199,6 +195,5 @@
         </td>
       </tr>
     </table>
-
   </body>
 </html>

--- a/services/email/templates/caseworker/html/error.mus
+++ b/services/email/templates/caseworker/html/error.mus
@@ -7,7 +7,7 @@
 <!--[if !IE]><!--> <html>             <!--<![endif]-->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-  <meta content="utf-8" http-equiv="encoding">
+    <meta content="utf-8" http-equiv="encoding">
     <!-- Use title if it's in the page YAML frontmatter -->
     <title>{{subject}}</title>
 </head>
@@ -52,59 +52,62 @@
             </tr>
             <tr>
               <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+
                 {{#data}}
-
                   <p style="font-size: 23px; color: #000; line-height: 1.32; margin: 0 0 20px 0;">{{#t}}emails.correct-mistakes.header{{/t}}</p>
-
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">BRP applicant's details</p>
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{fullname}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{date-of-birth}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.nationality{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.nationality{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nationality}}</p></td>
                     </tr>
-                    {{#brp-card}}
+
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.brp-card-number{{/t}}</p></td>
-                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{brp-card}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details-error.personal-details-table.headers.brp-card-number{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#brp-card}}{{brp-card}}{{/brp-card}}{{^brp-card}}None Given{{/brp-card}}</p></td>
                     </tr>
-                    {{/brp-card}}
+
                     {{#same-address-street}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}: </p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{same-address-house-number}} {{same-address-street}},
+                          {{same-address-town}},
+                          {{#same-address-county}}{{same-address-county}},{{/same-address-county}}
+                          {{same-address-postcode}}
+                        </p>
+                      </td>
+                    </tr>
+                    {{/same-address-street}}
+                    {{^same-address-street}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}: </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{same-address-house-number}} {{same-address-street}},
-                            {{same-address-town}},
-                            {{#same-address-county}}{{same-address-county}},{{/same-address-county}}
-                            {{same-address-postcode}}
+                            {{#uk-address-street}}
+                              {{uk-address-house-number}} {{uk-address-street}},
+                              {{uk-address-town}},
+                              {{#uk-address-county}}{{uk-address-county}},{{/uk-address-county}}
+                              {{uk-address-postcode}}
+                            {{/uk-address-street}}
+                            {{^uk-address-street}}None Given{{/uk-address-street}}
                           </p>
                         </td>
                       </tr>
                     {{/same-address-street}}
-                    {{#uk-address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}</p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{uk-address-house-number}} {{uk-address-street}},
-                            {{uk-address-town}},
-                            {{#uk-address-county}}{{uk-address-county}},{{/uk-address-county}}
-                            {{uk-address-postcode}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/uk-address-street}}
+
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
@@ -117,140 +120,110 @@
 
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Reported errors</p>
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                    {{#first-name-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.first-name-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{first-name-error}}</p></td>
-                      </tr>
-                    {{/first-name-error}}
 
-                    {{#last-name-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.last-name-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{last-name-error}}</p></td>
-                      </tr>
-                    {{/last-name-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.first-name-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#first-name-error}}{{first-name-error}}{{/first-name-error}}{{^first-name-error}}None Given{{/first-name-error}}</p></td>
+                    </tr>
 
-                    {{#birth-place-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.birth-place-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{birth-place-error}}</p></td>
-                      </tr>
-                    {{/birth-place-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.last-name-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#last-name-error}}{{last-name-error}}{{/last-name-error}}{{^last-name-error}}None Given{{/last-name-error}}</p></td>
+                    </tr>
 
-                    {{#date-of-birth-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.date-of-birth-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{date-of-birth-error}}</p></td>
-                      </tr>
-                    {{/date-of-birth-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.birth-place-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#birth-place-error}}{{birth-place-error}}{{/birth-place-error}}{{^birth-place-error}}None Given{{/birth-place-error}}</p></td>
+                    </tr>
 
-                    {{#gender-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.gender-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{gender-error}}</p></td>
-                      </tr>
-                    {{/gender-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.date-of-birth-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#date-of-birth-error}}{{date-of-birth-error}}{{/date-of-birth-error}}{{^date-of-birth-error}}None Given{{/date-of-birth-error}}</p></td>
+                    </tr>
 
-                    {{#sponsor-details-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.sponsor-details-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{sponsor-details-error}}</p></td>
-                      </tr>
-                    {{/sponsor-details-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.gender-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#gender-error}}{{gender-error}}{{/gender-error}}{{^gender-error}}None Given{{/gender-error}}</p></td>
+                    </tr>
 
-                    {{#nationality-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.nationality-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nationality-error}}</p></td>
-                      </tr>
-                    {{/nationality-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.sponsor-details-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#sponsor-details-error}}{{sponsor-details-error}}{{/sponsor-details-error}}{{^sponsor-details-error}}None Given{{/sponsor-details-error}}</p></td>
+                    </tr>
 
-                    {{#signature-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.signature-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{signature-error}}</p></td>
-                      </tr>
-                    {{/signature-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.nationality-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#nationality-error}}{{nationality-error}}{{/nationality-error}}{{^nationality-error}}None Given{{/nationality-error}}</p></td>
+                    </tr>
 
-                    {{#national-insurance-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.national-insurance-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{national-insurance-error}}</p></td>
-                      </tr>
-                    {{/national-insurance-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.signature-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#signature-error}}{{signature-error}}{{/signature-error}}{{^signature-error}}None Given{{/signature-error}}</p></td>
+                    </tr>
 
-                    {{#photograph-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.photograph-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{photograph-error}}</p></td>
-                      </tr>
-                    {{/photograph-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.national-insurance-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#national-insurance-error}}{{national-insurance-error}}{{/national-insurance-error}}{{^national-insurance-error}}None Given{{/national-insurance-error}}</p></td>
+                    </tr>
 
-                    {{#damaged-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.damaged-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{damaged-error}}</p></td>
-                      </tr>
-                    {{/damaged-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.photograph-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#photograph-error}}{{photograph-error}}{{/photograph-error}}{{^photograph-error}}None Given{{/photograph-error}}</p></td>
+                    </tr>
 
-                    {{#conditions-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.conditions-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{conditions-error}}</p></td>
-                      </tr>
-                    {{/conditions-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.damaged-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#damaged-error}}{{damaged-error}}{{/damaged-error}}{{^damaged-error}}None Given{{/damaged-error}}</p></td>
+                    </tr>
 
-                    {{#length-of-stay-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.length-of-stay-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{length-of-stay-error}}</p></td>
-                      </tr>
-                    {{/length-of-stay-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.conditions-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#conditions-error}}{{conditions-error}}{{/conditions-error}}{{^conditions-error}}None Given{{/conditions-error}}</p></td>
+                    </tr>
 
-                    {{#biographics-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.biographics-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{biographics-error}}</p></td>
-                      </tr>
-                    {{/biographics-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.length-of-stay-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#length-of-stay-error}}{{length-of-stay-error}}{{/length-of-stay-error}}{{^length-of-stay-error}}None Given{{/length-of-stay-error}}</p></td>
+                    </tr>
 
-                    {{#BRP-issue-error}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.BRP-issue-error-checkbox.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{BRP-issue-error}}</p></td>
-                      </tr>
-                    {{/BRP-issue-error}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.biographics-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#biographics-error}}{{biographics-error}}{{/biographics-error}}{{^biographics-error}}None Given{{/biographics-error}}</p></td>
+                    </tr>
 
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.BRP-issue-error-checkbox.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#BRP-issue-error}}{{BRP-issue-error}}{{/BRP-issue-error}}{{^BRP-issue-error}}None Given{{/BRP-issue-error}}</p></td>
+                    </tr>
                   </table>
 
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Contact details</p>
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                    {{#contact-address-street}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}: </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                            {{contact-address-house-number}} {{contact-address-street}},
-                            {{contact-address-town}},
-                            {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
-                            {{contact-address-postcode}}
+                            {{#contact-address-street}}
+                              {{contact-address-house-number}} {{contact-address-street}},
+                              {{contact-address-town}},
+                              {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
+                              {{contact-address-postcode}}
+                            {{/contact-address-street}}
+                            {{^contact-address-street}}None Given{{/contact-address-street}}
                           </p>
                         </td>
                       </tr>
-                    {{/contact-address-street}}
-                    {{#email}}
+
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.email.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{email}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.email.label{{/t}}: </p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#email}}{{email}}{{/email}}{{^email}}None Given{{/email}}</p></td>
                       </tr>
-                    {{/email}}
-                    {{#phone}}
+
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.phone.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{phone}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.phone.label{{/t}}: </p></td>
+                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#phone}}{{phone}}{{/phone}}{{^phone}}None Given{{/phone}}</p></td>
                       </tr>
-                    {{/phone}}
+
                   </table>
                 {{/data}}
               </td>

--- a/services/email/templates/caseworker/html/lost_or_stolen.mus
+++ b/services/email/templates/caseworker/html/lost_or_stolen.mus
@@ -7,7 +7,7 @@
 <!--[if !IE]><!--> <html>             <!--<![endif]-->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-  <meta content="utf-8" http-equiv="encoding">
+    <meta content="utf-8" http-equiv="encoding">
     <!-- Use title if it's in the page YAML frontmatter -->
     <title>{{subject}}</title>
 </head>
@@ -58,7 +58,7 @@
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.caseworker.country{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.caseworker.country{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">
                       {{#country}}
                         {{country}}
@@ -69,7 +69,7 @@
                       </p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.caseworker.date-lost{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.caseworker.date-lost{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{date-lost}}</p></td>
                     </tr>
                   </table>
@@ -78,26 +78,24 @@
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}</p></td>
-                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{fullname}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#fullname}}{{fullname}}{{/fullname}}{{^fullname}}None Given{{/fullname}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{date-of-birth}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nationality}}</p></td>
                     </tr>
-                    {{#brp-card}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.brp-card-number{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{brp-card}}</p></td>
-                      </tr>
-                    {{/brp-card}}
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.brp-card-number{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#brp-card}}{{brp-card}}{{/brp-card}}{{^brp-card}}None Given{{/brp-card}}</p></td>
+                    </tr>
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
@@ -108,35 +106,34 @@
                     {{/org-type}}
                   </table>
 
-
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Contact details</p>
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
-                    {{#contact-address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.address{{/t}}</p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.address{{/t}}: </p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#contact-address-street}}
                             {{contact-address-house-number}} {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/contact-address-street}}
-                    {{#phone}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.phone{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{phone}}</p></td>
-                      </tr>
-                    {{/phone}}
-                    {{#email}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.email.label{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{email}}</p></td>
-                      </tr>
-                    {{/email}}
+                          {{/contact-address-street}}
+                          {{^contact-address-street}}None Given{{/contact-address-street}}
+                        </p>
+                      </td>
+                    </tr>
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.phone{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#phone}}{{phone}}{{/phone}}{{^phone}}None Given{{/phone}}</p></td>
+                    </tr>
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.email.label{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#email}}{{email}}{{/email}}{{^email}}None Given{{/email}}</p></td>
+                    </tr>
+
                   </table>
                 {{/data}}
               </td>

--- a/services/email/templates/caseworker/html/someone-else.mus
+++ b/services/email/templates/caseworker/html/someone-else.mus
@@ -63,53 +63,51 @@
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{fullname}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#date-of-birth}}{{date-of-birth}}{{/date-of-birth}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{nationality}}</p></td>
                     </tr>
-                    {{#passport}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{passport}}</p></td>
-                      </tr>
-                    {{/passport}}
-                    {{#email}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.email{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{email}}</p></td>
-                      </tr>
-                    {{/email}}
-                    {{#phone}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.phone{{/t}}</p></td>
-                        <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{phone}}</p></td>
-                      </tr>
-                    {{/phone}}
-                    {{^email}}
-                    {{#contact-address-street}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}</p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.passport{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#passport}}{{passport}}{{/passport}}{{^passport}}None Given{{/passport}}</p></td>
+                    </tr>
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.email{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#email}}{{email}}{{/email}}{{^email}}None Given{{/email}}</p></td>
+                    </tr>
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.phone{{/t}}: </p></td>
+                      <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#phone}}{{phone}}{{/phone}}{{^phone}}None Given{{/phone}}</p></td>
+                    </tr>
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.contact-address{{/t}}: </p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                         {{#contact-address-street}}
                             {{contact-address-house-number}} {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/contact-address-street}}
-                    {{/email}}
+                          {{/contact-address-street}}
+                          {{^contact-address-street}}None Given{{/contact-address-street}}
+                        </p>
+                      </td>
+                    </tr>
+
                     {{#someone-else-reason-radio}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.someone-else.tables.personal-details.reason{{/t}}</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}emails.someone-else.tables.personal-details.reason{{/t}}: </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#t}}fields.someone-else-reason-radio.options.{{someone-else-reason-radio}}.label{{/t}}
@@ -122,9 +120,10 @@
                         </td>
                       </tr>
                     {{/someone-else-reason-radio}}
+
                     {{#org-type}}
                       <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}})</p></td>
+                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
@@ -140,23 +139,23 @@
 
                   <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF" style="margin: 0 0 20px 0;">
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.fullname{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{someone-else-fullname}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.date-of-birth{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{someone-else-date}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.nationality{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{someone-else-nationality}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.someone-else-id-type.legend{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}fields.someone-else-id-type.legend{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#t}}fields.someone-else-id-type.options.{{someone-else-id-type}}.label{{/t}}</p></td>
                     </tr>
                     <tr style="border-top: 1px solid #009390;">
-                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.id-number{{/t}}</p></td>
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.id-number{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{someone-else-id-number}}</p></td>
                     </tr>
                   </table>
@@ -169,6 +168,5 @@
         </td>
       </tr>
     </table>
-
   </body>
 </html>

--- a/services/email/templates/caseworker/plain/delivery.mus
+++ b/services/email/templates/caseworker/plain/delivery.mus
@@ -3,10 +3,10 @@
 
 Personal Details
 
-{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}
+{{#t}}pages.check-details-error.personal-details-table.headers.fullname{{/t}}:
 {{fullname}}
 
-{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}
+{{#t}}pages.check-details-error.personal-details-table.headers.date-of-birth{{/t}}:
 {{date-of-birth}}
 
 {{#t}}pages.check-details-error.personal-details-table.headers.nationality{{/t}}
@@ -54,6 +54,11 @@ Delivery Details
 {{#t}}pages.check-details.table.headers.delivery-date{{/t}}
 {{delivery-date}}
 {{/delivery-date}}
+
+{{#case-id-number}}
+{{#t}}pages.check-details.table.headers.case-id-number{{/t}}
+{{case-id-number}}
+{{/case-id-number}}
 
 {{^address-street}}
 {{#delivery-details}}

--- a/test/_features/brp/not_arrived.feature
+++ b/test/_features/brp/not_arrived.feature
@@ -1,6 +1,6 @@
 @feature @not_arrived
 Feature: I should be able to log that my BRP has not arrived
-  
+
   Scenario: Due to collect the document from the postcode
     Given I start the 'not-arrived' application journey
     Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
@@ -32,6 +32,7 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
     Then I check 'received-yes'
     Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I fill 'case-id-number' with 'ID123456789'
     Then I select 'Continue'
     Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
     Then I check 'address-match-yes'
@@ -59,6 +60,7 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
     Then I check 'received-yes'
     Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I fill 'case-id-number' with 'ID123456789'
     Then I select 'Continue'
     Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
     Then I check 'address-match-no'
@@ -95,6 +97,7 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
     Then I check 'received-yes'
     Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I fill 'case-id-number' with 'ID123456789'
     Then I select 'Continue'
     Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
     Then I check 'address-match-yes'
@@ -119,6 +122,7 @@ Feature: I should be able to log that my BRP has not arrived
     Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
     Then I check 'received-yes'
     Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I fill 'case-id-number' with 'ID123456789'
     Then I select 'Continue'
     Then I should be on the 'same-address' page showing 'Would you like your BRP sent to the address that is on the letter from the Home Office?'
     Then I check 'address-match-yes'
@@ -134,3 +138,19 @@ Feature: I should be able to log that my BRP has not arrived
     Then I fill 'email' with 'test@test.test'
     Then I select 'Continue'
     Then I should be on the 'confirm' page showing 'Check the details you have provided'
+
+  @validation
+  Scenario: Not arrived application changing mind on letter recieved
+    Given I start the 'not-arrived' application journey
+    Then I should be on the 'post-office-collect' page showing 'Were you due to collect your document from the Post Office?'
+    Then I check 'collection-no'
+    Then I select 'Continue'
+    Then I should be on the 'consignment-number' page showing 'Do you have a consignment number?'
+    Then I check 'consignment-number-radio-no'
+    Then I select 'Continue'
+    Then I should be on the 'letter-received' page showing 'Have you received your decision by letter or email?'
+    Then I check 'received-yes'
+    Then I fill the date 'delivery-date' with '24-5-2020'
+    Then I check 'no-letter'
+    Then I select 'Continue'
+    Then I should be on the 'letter-lost' page showing 'Contact us'


### PR DESCRIPTION
**Changes**

- letter-received.html updated to include new case-id-number fields in not-arrived route.
- new case-id-number fields added to pages.json, fields.json, and index.js within not-arrived route.
- Email templates changed to include a comma after the field name, and updated to include all fields in the email with 'None Given' for fields with no information obtained from the user.
- Updated acceptance tests to include the new case-id-number field.
- Fixed data issues with email, phone number and county address not appearing on emails on all routes.

**Reason**
Changes above requested by the business. 