### PR TITLE
BRP-98: Changes to the email templates on all routes

### DIFF
--- a/services/email/templates/caseworker/html/collection.mus
+++ b/services/email/templates/caseworker/html/collection.mus
@@ -162,7 +162,7 @@
                       <td width="75%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                           {{#contact-address-street}}
-                            {{contact-address-house-number}} {{contact-address-street}},
+                            {{#contact-address-house-number}}{{contact-address-house-number}}{{/contact-address-house-number}}{{^contact-address-house-number}}None Given{{/contact-address-house-number}}, {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
@@ -172,17 +172,19 @@
                       </td>
                     </tr>
 
-                    {{#org-type}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from{{#org-type}} ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): {{/org-type}}{{^org-type}}: None Given{{/org-type}}</p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#org-type}}
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
                             {{^rep-email}}{{rep-name}}{{/rep-email}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/org-type}}
+                          {{/org-type}}
+                          {{^org-type}}None Given{{/org-type}}
+                        </p>
+                      </td>
+                    </tr>
+
                   </table>
                 {{/data}}
               </td>

--- a/services/email/templates/caseworker/html/delivery.mus
+++ b/services/email/templates/caseworker/html/delivery.mus
@@ -85,7 +85,7 @@
                       <td width="75%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                           {{#address-street}}
-                            {{address-house-number}} {{address-street}},
+                            {{#address-house-number}}{{address-house-number}}{{/address-house-number}}{{^address-house-number}}None Given{{/address-house-number}}, {{address-street}},
                             {{address-town}},
                             {{#address-county}}{{address-county}},{{/address-county}}
                             {{address-postcode}}
@@ -94,17 +94,19 @@
                         </p>
                       </td>
                     </tr>
-                    {{#org-type}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from{{#org-type}} ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): {{/org-type}}{{^org-type}}: None Given{{/org-type}}</p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#org-type}}
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
                             {{^rep-email}}{{rep-name}}{{/rep-email}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/org-type}}
+                          {{/org-type}}
+                          {{^org-type}}None Given{{/org-type}}
+                        </p>
+                      </td>
+                    </tr>
                   </table>
 
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Contact Details</p>
@@ -115,7 +117,7 @@
                       <td width="75%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                           {{#contact-address-street}}
-                            {{contact-address-house-number}} {{contact-address-street}},
+                            {{#contact-address-house-number}}{{contact-address-house-number}}{{/contact-address-house-number}}{{^contact-address-house-number}}None Given{{/contact-address-house-number}}, {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
@@ -169,7 +171,7 @@
                           <td width="75%">
                             <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#address-street}}
-                              {{address-house-number}} {{address-street}},
+                              {{#address-house-number}}{{address-house-number}}{{/address-house-number}}{{^address-house-number}}None Given{{/address-house-number}}, {{address-street}},
                               {{address-town}},
                               {{#address-county}}{{address-county}},{{/address-county}}
                               {{address-postcode}}

--- a/services/email/templates/caseworker/html/error.mus
+++ b/services/email/templates/caseworker/html/error.mus
@@ -80,7 +80,7 @@
                       <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.address{{/t}}: </p></td>
                       <td width="75%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
-                          {{same-address-house-number}} {{same-address-street}},
+                          {{#same-address-house-number}}{{same-address-house-number}}{{/same-address-house-number}}{{^same-address-house-number}}None Given{{/same-address-house-number}}, {{same-address-street}},
                           {{same-address-town}},
                           {{#same-address-county}}{{same-address-county}},{{/same-address-county}}
                           {{same-address-postcode}}
@@ -94,7 +94,7 @@
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#uk-address-street}}
-                              {{uk-address-house-number}} {{uk-address-street}},
+                              {{#uk-address-house-number}}{{uk-address-house-number}}{{/uk-address-house-number}}{{^uk-address-house-number}}None Given{{/uk-address-house-number}}, {{uk-address-street}},
                               {{uk-address-town}},
                               {{#uk-address-county}}{{uk-address-county}},{{/uk-address-county}}
                               {{uk-address-postcode}}
@@ -105,17 +105,18 @@
                       </tr>
                     {{/same-address-street}}
 
-                    {{#org-type}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from{{#org-type}} ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): {{/org-type}}{{^org-type}}: None Given{{/org-type}}</p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#org-type}}
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
                             {{^rep-email}}{{rep-name}}{{/rep-email}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/org-type}}
+                          {{/org-type}}
+                          {{^org-type}}None Given{{/org-type}}
+                        </p>
+                      </td>
+                    </tr>
                   </table>
 
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Reported errors</p>
@@ -204,7 +205,7 @@
                         <td width="75%">
                           <p style="font-size: 16px; color: #000; margin: 10px 0;">
                             {{#contact-address-street}}
-                              {{contact-address-house-number}} {{contact-address-street}},
+                              {{#contact-address-house-number}}{{contact-address-house-number}}{{/contact-address-house-number}}{{^contact-address-house-number}}None Given{{/contact-address-house-number}}, {{contact-address-street}},
                               {{contact-address-town}},
                               {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                               {{contact-address-postcode}}

--- a/services/email/templates/caseworker/html/lost_or_stolen.mus
+++ b/services/email/templates/caseworker/html/lost_or_stolen.mus
@@ -93,17 +93,20 @@
                       <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">{{#t}}pages.check-details.table.headers.brp-card-number{{/t}}: </p></td>
                       <td width="75%"><p style="font-size: 16px; color: #000; margin: 10px 0;">{{#brp-card}}{{brp-card}}{{/brp-card}}{{^brp-card}}None Given{{/brp-card}}</p></td>
                     </tr>
-                    {{#org-type}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from{{#org-type}} ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): {{/org-type}}{{^org-type}}: None Given{{/org-type}}</p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#org-type}}
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
                             {{^rep-email}}{{rep-name}}{{/rep-email}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/org-type}}
+                          {{/org-type}}
+                          {{^org-type}}None Given{{/org-type}}
+                        </p>
+                      </td>
+                    </tr>
+
                   </table>
 
                   <p style="font-size: 19px; font-weight: bold; color: #000; line-height: 1.32; margin: 0 0 10px 0;">Contact details</p>
@@ -114,7 +117,7 @@
                       <td width="75%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                           {{#contact-address-street}}
-                            {{contact-address-house-number}} {{contact-address-street}},
+                            {{#contact-address-house-number}}{{contact-address-house-number}}{{/contact-address-house-number}}{{^contact-address-house-number}}None Given{{/contact-address-house-number}}, {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}

--- a/services/email/templates/caseworker/html/someone-else.mus
+++ b/services/email/templates/caseworker/html/someone-else.mus
@@ -95,7 +95,7 @@
                       <td width="75%">
                         <p style="font-size: 16px; color: #000; margin: 10px 0;">
                          {{#contact-address-street}}
-                            {{contact-address-house-number}} {{contact-address-street}},
+                            {{#contact-address-house-number}}{{contact-address-house-number}}{{/contact-address-house-number}}{{^contact-address-house-number}}None Given{{/contact-address-house-number}}, {{contact-address-street}},
                             {{contact-address-town}},
                             {{#contact-address-county}}{{contact-address-county}},{{/contact-address-county}}
                             {{contact-address-postcode}}
@@ -121,17 +121,18 @@
                       </tr>
                     {{/someone-else-reason-radio}}
 
-                    {{#org-type}}
-                      <tr style="border-top: 1px solid #009390;">
-                        <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): </p></td>
-                        <td width="75%">
-                          <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                    <tr style="border-top: 1px solid #009390;">
+                      <td width="25%"><p style="font-size: 16px; color: #6f777b; margin: 10px 0;">Help from{{#org-type}} ({{#t}}fields.org-type.options[{{org-type}}].label{{/t}}): {{/org-type}}{{^org-type}}: None Given{{/org-type}}</p></td>
+                      <td width="75%">
+                        <p style="font-size: 16px; color: #000; margin: 10px 0;">
+                          {{#org-type}}
                             {{#rep-email}}<a href="mailto:{{rep-email}}">{{rep-name}} &lt;{{rep-email}}&gt;</a>{{/rep-email}}
                             {{^rep-email}}{{rep-name}}{{/rep-email}}
-                          </p>
-                        </td>
-                      </tr>
-                    {{/org-type}}
+                          {{/org-type}}
+                          {{^org-type}}None Given{{/org-type}}
+                        </p>
+                      </td>
+                    </tr>
                   </table>
 
                   <!-- OTHER PERSONS DETAILS TABLE -->


### PR DESCRIPTION
**Changes**

- Changes made to address format on the email. 
- Changes made to "help-from" on all routes so default text 'None Given' is shown in the email when user does not give any sponsor information.

**Reason**

- Changes requested by the business as follow up changes from ticket BRP-95. 

**Testing**

- Tested by QAT on branch.