### PR TITLE
Fixed issue with dup emails going to wrong email addr and added unit tests

### DIFF
--- a/apps/common/behaviours/email.js
+++ b/apps/common/behaviours/email.js
@@ -19,9 +19,7 @@ function errorChecked(key, data) {
 
 function setRef(data) {
   const submissionRef = (data['submission-reference'] ? data['submission-reference'] : nanoid());
-  if (data['submission-reference']) {
-    config.email.duplicate = true;
-  }
+  data['is-resubmission'] = data['previous-submission'] === 'yes' ? true : false;
   return submissionRef;
 }
 
@@ -76,7 +74,7 @@ module.exports = superclass => class Emailer extends superclass {
     super.saveValues(req, res, () => {
       const data = _.pick(req.sessionModel.toJSON(), _.identity);
       const service = serviceMap[req.baseUrl] && serviceMap[req.baseUrl](data);
-
+      
       if (!service) {
         return callback(new Error('no service found'));
       }

--- a/apps/common/models/email.js
+++ b/apps/common/models/email.js
@@ -11,6 +11,7 @@ module.exports = class Email extends Model {
       template: this.get('template'),
       to: this.get('email'),
       subject: this.get('subject'),
+      isResubmission: this.get('is-resubmission'),
       dataToSend: _.omit(this.toJSON(), ['steps', 'csrf-secret', 'template'])
     }, callback);
   }

--- a/services/email/index.js
+++ b/services/email/index.js
@@ -171,7 +171,7 @@ Emailer.prototype.send = function send(email, callback) {
     logger.info(`Emailing caseworker: ${email.subject}`);
     this.transporter.sendMail({
       from: config.email.from,
-      to: config.email.duplicate ? config.email.caseworker.duplicate : config.email.caseworker[email.template],
+      to: email.isResubmission ? config.email.caseworker.duplicate : config.email.caseworker[email.template],
       subject: email.subject,
       text: Hogan.compile(caseworkerPlainTextTemplates[email.template]).render(templateData),
       html: Hogan.compile(caseworkerHtmlTemplates[email.template]).render(templateData),

--- a/test/_unit/apps/common/behaviours/email.spec.js
+++ b/test/_unit/apps/common/behaviours/email.spec.js
@@ -12,18 +12,21 @@ describe('apps/common/controllers/confirm', () => {
     let setStub;
     let saveStub;
     let constructorStub;
-
+ 
     beforeEach(done => {
       constructorStub = sinon.stub();
       setStub = sinon.stub();
       saveStub = sinon.stub();
-
+      
       Behaviour = proxyquire('../apps/common/behaviours/email', {
         '../models/email': constructorStub.returns({
           set: setStub,
           save: saveStub.yieldsAsync()
         }),
-        'hot-shots': sinon.stub().returns({ increment: sinon.stub() })
+        'hot-shots': sinon.stub().returns({ increment: sinon.stub() }),
+        nanoid: {
+          customAlphabet: sinon.stub().returns(function () { return 'fpgyxSgw7' })
+        }
       });
 
       req = reqres.req({
@@ -42,7 +45,7 @@ describe('apps/common/controllers/confirm', () => {
       req.baseUrl = '/collection';
       controller.saveValues(req, res, err => {
         expect(err).not.to.be.ok;
-        constructorStub.should.have.been.calledWith({ foo: 'bar' });
+        constructorStub.should.have.been.calledWith({ foo: 'bar', 'is-resubmission': false });
         saveStub.should.have.been.called;
       });
     });
@@ -110,12 +113,58 @@ describe('apps/common/controllers/confirm', () => {
       });
     });
 
-
     it('throws an error if its not part of a recognised journey', () => {
       req.baseUrl = '/unrecognised-journey';
       controller.saveValues(req, res, err => {
         err.should.be.an('error');
         err.message.should.equal('no service found');
+      });
+    });
+
+    it('correctly marks an email as a resubmission with the correct reference in the email subject when a reference is supplied', () => {
+      req.baseUrl = '/collection';
+      req.sessionModel.set('previous-submission', 'yes');
+      req.sessionModel.set('submission-reference', '123456');
+      
+      controller.saveValues(req, res, err => {
+        setStub.should.have.been.calledWith('subject',
+          'Form submitted: Report a collection problem. Ref: 123456');
+        constructorStub.should.have.been.calledWith({
+          foo: 'bar',
+          'previous-submission': 'yes',
+          'submission-reference': '123456',
+          'is-resubmission': true
+        });
+      });
+    });
+
+    it('correctly marks an email as a resubmission with a new random reference in the email subject when a previous reference is not supplied', () => {
+      req.baseUrl = '/collection';
+      req.sessionModel.set('previous-submission', 'yes');
+
+      controller.saveValues(req, res, err => {
+        setStub.should.have.been.calledWith('subject',
+          'Form submitted: Report a collection problem. Ref: fpgyxSgw7');
+        constructorStub.should.have.been.calledWith({
+          foo: 'bar',
+          'previous-submission': 'yes',
+          'is-resubmission': true
+        });
+      });
+    });
+
+    it('correctly marks an email as a not a resubmission with a new random reference in the email subject', () => {
+      req.baseUrl = '/collection';
+      req.sessionModel.set('previous-submission', 'no');
+
+      controller.saveValues(req, res, err => {
+        setStub.should.have.been.calledWith('subject',
+          'Form submitted: Report a collection problem. Ref: fpgyxSgw7');
+        constructorStub.should.have.been.calledWith({
+          foo: 'bar',
+          'previous-submission': 'no',
+          'is-resubmission': false
+        });
       });
     });
   });

--- a/test/_unit/apps/common/models/email.spec.js
+++ b/test/_unit/apps/common/models/email.spec.js
@@ -16,7 +16,8 @@ describe('apps/common/models/email', () => {
         email: 'email@email.com',
         subject: 'email subject',
         name: 'dave',
-        other: 'data'
+        other: 'data',
+        'is-resubmission': false
       });
     });
 
@@ -30,11 +31,13 @@ describe('apps/common/models/email', () => {
           template: 'test_template',
           to: 'email@email.com',
           subject: 'email subject',
+          isResubmission: false,
           dataToSend: {
             email: 'email@email.com',
             name: 'dave',
             other: 'data',
-            subject: 'email subject'
+            subject: 'email subject',
+            'is-resubmission': false
           }
         });
       });


### PR DESCRIPTION
What:
The previous work done on this ticket had mistakes, in particular the duplicate boolean that was being set in the config - This should have been in session since it is never reset back to false after a dup email is sent.

Also added a bunch of unit tests to make sure we're covering the right scenarios when sending a dup email.