### PR TITLE
BRP-131: Change input type for phone numbers

### DIFF
--- a/apps/collection/fields/index.js
+++ b/apps/collection/fields/index.js
@@ -95,7 +95,8 @@ module.exports = {
   },
   phone: {
     label: 'fields.phone.label',
-    className: ['govuk-input', 'govuk-input--width-20']
+    className: ['govuk-input', 'govuk-input--width-20'],
+    type: 'tel'
   },
   'contact-address-county': {
     label: 'fields.address-county.label',

--- a/apps/correct-mistakes/fields/uk-address.js
+++ b/apps/correct-mistakes/fields/uk-address.js
@@ -63,7 +63,8 @@ module.exports = {
   },
   phone: {
     label: 'fields.phone.label',
-    className: ['govuk-input', 'govuk-input--width-20']
+    className: ['govuk-input', 'govuk-input--width-20'],
+    type: 'tel'
   },
   'contact-address-county': {
     label: 'fields.address-county.label',

--- a/apps/lost-stolen/fields/personal-details.js
+++ b/apps/lost-stolen/fields/personal-details.js
@@ -53,7 +53,8 @@ module.exports = {
   },
   phone: {
     label: 'fields.phone.label',
-    className: ['govuk-input', 'govuk-input--width-20']
+    className: ['govuk-input', 'govuk-input--width-20'],
+    type: 'tel'
   },
   'contact-address-county': {
     label: 'fields.address-county.label',

--- a/apps/lost-stolen/translations/src/en/emails.json
+++ b/apps/lost-stolen/translations/src/en/emails.json
@@ -57,8 +57,5 @@
     "eea-header": "EEA Nationals",
     "eea-paragraph-one": "If you’re exercising EEA treaty rights in the UK, you can choose whether or not to replace your residence card. You will not receive a penalty if you don’t replace it.",
     "eea-paragraph-two": "If you apply for a replacement EEA treaty rights residence card and later have an urgent need to travel, you can discuss your options with the European Enquiries contact centre on 0300 123 2253."
-  },
-  "you-sent": "Here is the information you have sent us",
-  "address": "Contact address",
-  "phone": "Phone number"
+  }
 }

--- a/apps/not-arrived/fields/address-match.js
+++ b/apps/not-arrived/fields/address-match.js
@@ -78,7 +78,8 @@ module.exports = {
   },
   phone: {
     label: 'fields.phone.label',
-    className: ['govuk-input', 'govuk-input--width-20']
+    className: ['govuk-input', 'govuk-input--width-20'],
+    type: 'tel'
   },
   'contact-address-county': {
     label: 'fields.address-county.label',

--- a/apps/someone-else/fields/reason.js
+++ b/apps/someone-else/fields/reason.js
@@ -27,7 +27,8 @@ module.exports = {
   },
   phone: {
     label: 'fields.phone.label',
-    className: ['govuk-input', 'govuk-input--width-20']
+    className: ['govuk-input', 'govuk-input--width-20'],
+    type: 'tel'
   },
   'contact-address-county': {
     label: 'fields.address-county.label',


### PR DESCRIPTION
## What? 
-  Change input type for phone number fields - [BRP-131](https://collaboration.homeoffice.gov.uk/jira/browse/BRP-131)
## Why? 
- The type value for the phone number textbox is set as "text" when it should be set as "tel".
## How? 
- Add 'tel' type to phone fields config
## Testing?
- Tests passing locally
## Screenshots (optional)
Before change:
![phone number](https://github.com/user-attachments/assets/2a7c8756-c8bb-474e-93d1-02e89d0bfc33)

After change:
<img width="964" alt="Screenshot 2024-07-22 at 14 40 18" src="https://github.com/user-attachments/assets/f5223d87-1e35-49a7-b6a8-7eff55a46ffb">

## Anything Else? (optional)
- Remove duplicate properties in lost-stolen/emails.json
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
