### PR TITLE
EEC-28: BRP Error webform - restrict IPS

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -165,8 +165,10 @@ steps:
     commands:
       - bin/deploy.sh $${BRANCH_ENV}
     when:
-      branch: master
-      event: pull_request
+      # branch: master
+      event:
+      - pull_request
+      - push
 
   - name: setup_branch
     pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   STG_ENV: brp-stg
   UAT_ENV: brp-uat
   BRANCH_ENV: brp-branch
-  PRODUCTION_URL:  www.report-error-evisa.homeoffice.gov.uk 
+  PRODUCTION_URL: www.biometric-residence-permit.service.gov.uk
   IMAGE_URL: quay.io/ukhomeofficedigital
   IMAGE_REPO: brpapp
   GIT_REPO: UKHomeOffice/brp_enquiry_forms

--- a/.drone.yml
+++ b/.drone.yml
@@ -165,10 +165,9 @@ steps:
     commands:
       - bin/deploy.sh $${BRANCH_ENV}
     when:
-      # branch: master
+      branch: master
       event:
       - pull_request
-      - push
 
   - name: setup_branch
     pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   STG_ENV: brp-stg
   UAT_ENV: brp-uat
   BRANCH_ENV: brp-branch
-  PRODUCTION_URL: www.biometric-residence-permit.service.gov.uk
+  PRODUCTION_URL:  www.report-error-evisa.homeoffice.gov.uk 
   IMAGE_URL: quay.io/ukhomeofficedigital
   IMAGE_REPO: brpapp
   GIT_REPO: UKHomeOffice/brp_enquiry_forms

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -32,7 +32,7 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/redis -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
-  $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml -f kube/app/ingress-external-restriction.yml
+  $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
   $kd -f kube/redis -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -32,7 +32,7 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/redis -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
-  $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
+  $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml -f kube/app/ingress-external-restriction.yml
   $kd -f kube/redis -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -36,7 +36,7 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/redis -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
-  $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
+  $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml -f kube/app/ingress-external-restriction.yml
   $kd -f kube/redis -f kube/app/deployment.yml
 fi
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,6 +4,8 @@ set -e
 export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yaml
 #Whitelist updated with POISE IPs
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
+export INGRESS_EXTERNAL_RESTRICTED_ANNOTATIONS=$HOF_CONFIG/ingress-external-restricted-annotation.yaml
+
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 

--- a/kube/app/ingress-external-restriction.yml
+++ b/kube/app/ingress-external-restriction.yml
@@ -7,7 +7,7 @@ metadata:
   {{ else }}
   name: {{ .APP_NAME }}-external
   {{ end }}
-{{ file .INGRESS_EXTERNAL_ANNOTATIONS | indent 2 }}
+{{ file .INGRESS_EXTERNAL_RESTRICTED_ANNOTATIONS | indent 2 }}
 
 spec:
   tls:
@@ -35,7 +35,8 @@ spec:
     {{ end }}
       http:
         paths:
-          - path: /
+          - path: /correct-mistakes
+            pathType: Prefix
             backend:
               {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               serviceName: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}

--- a/kube/app/ingress-internal.yml
+++ b/kube/app/ingress-internal.yml
@@ -3,11 +3,14 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-  name: {{ .APP_NAME }}-internal-{{ .DRONE_SOURCE_BRANCH }}
+    name: redirect-ingress
+    annotations:
+      nginx.ingress.kubernetes.io/permanent-redirect: "www.report-error-evisa.homeoffice.gov.uk"
+      kubernetes.io/ingress.class: nginx
   {{ else }}
   name: {{ .APP_NAME }}-internal
   {{ end }}
-{{ file .INGRESS_INTERNAL_ANNOTATIONS | indent 2 }}
+# {{ file .INGRESS_INTERNAL_ANNOTATIONS | indent 2 }}
 spec:
   tls:
     - hosts:
@@ -37,6 +40,7 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
               {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               serviceName: {{ .APP_NAME }}-{{ .DRONE_SOURCE_BRANCH }}

--- a/kube/app/ingress-internal.yml
+++ b/kube/app/ingress-internal.yml
@@ -3,14 +3,11 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    name: redirect-ingress
-    annotations:
-      nginx.ingress.kubernetes.io/permanent-redirect: "www.report-error-evisa.homeoffice.gov.uk"
-      kubernetes.io/ingress.class: nginx
+  name: {{ .APP_NAME }}-internal-{{ .DRONE_SOURCE_BRANCH }}
   {{ else }}
   name: {{ .APP_NAME }}-internal
   {{ end }}
-# {{ file .INGRESS_INTERNAL_ANNOTATIONS | indent 2 }}
+{{ file .INGRESS_INTERNAL_ANNOTATIONS | indent 2 }}
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
## What?

GDS is decommissioning error correction via https://www.biometric-residence-permit.service.gov.uk/correct-mistakes/location, so this is to add restriction to public access.

## Why?
[EEC-28](https://collaboration.homeoffice.gov.uk/jira/browse/EEC-28) - BRP Error webform - restrict IPS and removal of all links

## How?
Adding a secondary ingress restricts to that path

## Testing?
See if access is indeed restricted

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
