### PR TITLE
BRP-204 Fix acceptance test fill step for typeahead inputs

### DIFF
--- a/test/_features/step_definitions/steps.js
+++ b/test/_features/step_definitions/steps.js
@@ -39,7 +39,22 @@ Then('I submit the application', { timeout: 4 * 5000 }, async function () {
 }.bind(World));
 
 Then('I fill {string} with {string}', async function (field, value) {
-  await this.page.fill(`input[name="${field}"]`, value);
+  const namedInput = this.page.locator(`input[name="${field}"]`).first();
+
+  if (await namedInput.count()) {
+    await namedInput.fill(value);
+    return;
+  }
+
+  const autocompleteInput = this.page.locator(`input#${field}`).first();
+
+  if (await autocompleteInput.count()) {
+    await autocompleteInput.fill(value);
+    await autocompleteInput.press('Tab');
+    return;
+  }
+
+  throw new Error(`Unable to find an input for field "${field}"`);
 }.bind(World));
 
 Then('I fill {string} text area with {string}', async function (field, value) {


### PR DESCRIPTION
## What? 

Updated the shared Playwright/Cucumber fill helper in test/_features/step_definitions/steps.js so acceptance tests work with accessible-autocomplete fields introduced by the typeahead UI. The step now fills standard inputs by name, falls back to autocomplete inputs by id, and tabs out to commit the selection. This fixes repeated acceptance failures across journeys such as collection, someone-else, and not-arrived where nationality fields were timing out after the typeahead change.

## Why? 
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
